### PR TITLE
Pin the component images a release is built against

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,11 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          # From go.mod, not a hardcoded version. Pinned at 1.23 while go.mod asked for
+          # 1.25.0, the toolchain that ran was not the one setup-go installed, and
+          # `go test -coverprofile` failed with `no such tool "covdata"` — CI had been
+          # red on every commit since March because of it.
+          go-version-file: go.mod
           cache: true
 
       - name: Download dependencies
@@ -44,13 +48,18 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        # v8 of the action for golangci-lint v2. `version: latest` on the v6 action
+        # resolved to 1.64.8, which is built with go1.24 and refuses a go1.25 target
+        # outright: "the Go language version used to build golangci-lint is lower than
+        # the targeted Go version". Pinned rather than floating so a new release cannot
+        # turn this red on an unrelated commit.
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: latest
+          version: v2.12.2
 
   build:
     name: Build
@@ -65,7 +74,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
           cache: true
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,38 @@ jobs:
           go-version: "1.23"
           cache: true
 
+      # Resolve the images this release is built against to immutable digests, so the
+      # binary declares exactly which components it works with instead of following a
+      # tag that moves under it. `:latest` is what a source build falls back to; it is
+      # not what ships.
+      #
+      # The digest taken is the manifest LIST digest, so it still resolves per
+      # architecture on the user's machine.
+      - name: Resolve component image digests
+        run: |
+          set -euo pipefail
+          resolve() {
+            local repo="$1" var="$2" digest
+            digest=$(docker buildx imagetools inspect "ghcr.io/antimatter-studios/${repo}:latest" \
+              --format '{{ .Manifest.Digest }}')
+            case "$digest" in
+              sha256:*) ;;
+              *) echo "unexpected digest for ${repo}: ${digest}" >&2; exit 1 ;;
+            esac
+            echo "${var}=ghcr.io/antimatter-studios/${repo}@${digest}" >> "$GITHUB_ENV"
+            echo "  ${repo} -> ${digest}"
+          }
+          resolve docker-dns DDT_DNS_IMAGE
+          resolve docker-proxy DDT_PROXY_IMAGE
+          resolve docker-config-gen DDT_CONFIG_GEN_IMAGE
+
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
-          version: latest
+          # Pinned, not `latest`: goreleaser builds the binary users install and writes
+          # the Homebrew cask, so it is part of the supply chain.
+          version: v2.17.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ Thumbs.db
 # Misc
 ZOLD*
 .task/checksum/*
+
+# Editor local-history snapshots (VS Code Local History and similar)
+.history/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,6 +22,19 @@ builds:
       - -X main.version={{.Version}}
       - -X main.commit={{.Commit}}
       - -X main.date={{.Date}}
+      # The images THIS ddt is compatible with, as immutable digests resolved by the
+      # release workflow just before this runs. A binary then always drives the
+      # components it was released against, which matters because some pairs are only
+      # correct together — a proxy image whose template expects a value its generator
+      # does not supply yet renders an nginx config that will not load.
+      #
+      # Guarded so a build from source still works: with the variables unset nothing is
+      # stamped, the defaults in internal/config stay at :latest, and startup leaves
+      # every configured docker_image alone. Stamping an empty string instead would
+      # write empty image names into a fresh config.
+      - '{{ if isEnvSet "DDT_DNS_IMAGE" }}-X github.com/christhomas/docker-dev-tools/internal/config.DNSImage={{ .Env.DDT_DNS_IMAGE }}{{ end }}'
+      - '{{ if isEnvSet "DDT_PROXY_IMAGE" }}-X github.com/christhomas/docker-dev-tools/internal/config.ProxyImage={{ .Env.DDT_PROXY_IMAGE }}{{ end }}'
+      - '{{ if isEnvSet "DDT_CONFIG_GEN_IMAGE" }}-X github.com/christhomas/docker-dev-tools/internal/config.ConfigGenImage={{ .Env.DDT_CONFIG_GEN_IMAGE }}{{ end }}'
 
 archives:
   - formats:

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -77,7 +77,6 @@ docker-dev-tools/
 │       ├── project.go        # Project model
 │       ├── script.go         # Script/run configuration
 │       └── docker.go         # Docker profile models
-├── proxy-config/             # NGINX proxy configuration (carried over)
 ├── docs/                     # Documentation
 │   └── PLAN.md               # This file
 ├── .github/workflows/        # CI/CD

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,10 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/term v0.2.2
+	github.com/containerd/errdefs v1.0.0
 	github.com/docker/docker v28.5.2+incompatible
+	github.com/docker/go-connections v0.6.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/spf13/cobra v1.10.2
 )
@@ -19,15 +22,12 @@ require (
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
-	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2,8 +2,6 @@ package app
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"runtime"
 
 	"github.com/christhomas/docker-dev-tools/internal/config"
@@ -35,7 +33,6 @@ type App struct {
 	Project  *service.ProjectService
 	Runner   *service.RunnerService
 	Git      *service.GitService
-	ToolsDir string // directory containing proxy-config/, etc.
 }
 
 // New creates and wires up a new App instance.
@@ -43,11 +40,10 @@ func New(build BuildInfo) *App {
 	cfg := config.LoadOrDefault()
 	plat := platform.Detect()
 	dockerClient := docker.NewClient()
-	toolsDir := detectToolsDir()
 
 	ipSvc := service.NewIPService(cfg, plat)
 	dnsSvc := service.NewDNSService(cfg, dockerClient, plat)
-	proxySvc := service.NewProxyService(cfg, dockerClient, toolsDir)
+	proxySvc := service.NewProxyService(cfg, dockerClient)
 	projectSvc := service.NewProjectService(cfg)
 	gitSvc := service.NewGitService()
 	runnerSvc := service.NewRunnerService(cfg, projectSvc)
@@ -63,31 +59,5 @@ func New(build BuildInfo) *App {
 		Project:  projectSvc,
 		Runner:   runnerSvc,
 		Git:      gitSvc,
-		ToolsDir: toolsDir,
 	}
-}
-
-// detectToolsDir finds the project root (where proxy-config/ lives).
-// It walks up from the executable location looking for proxy-config/.
-// Falls back to the current working directory.
-func detectToolsDir() string {
-	// Try executable directory first.
-	exe, err := os.Executable()
-	if err == nil {
-		dir := filepath.Dir(exe)
-		// If exe is in bin/, go up one level.
-		if filepath.Base(dir) == "bin" {
-			dir = filepath.Dir(dir)
-		}
-		if _, err := os.Stat(filepath.Join(dir, "proxy-config")); err == nil {
-			return dir
-		}
-	}
-
-	// Fall back to CWD.
-	if cwd, err := os.Getwd(); err == nil {
-		return cwd
-	}
-
-	return "."
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 
 	"github.com/christhomas/docker-dev-tools/internal/config"
@@ -38,6 +39,14 @@ type App struct {
 // New creates and wires up a new App instance.
 func New(build BuildInfo) *App {
 	cfg := config.LoadOrDefault()
+
+	// Loading may have rewritten a docker_image to match the digests this build pins.
+	// On stderr so it never lands in the output of a command being parsed, but said out
+	// loud — a silently replaced image is the one thing this mechanism must not do.
+	for _, note := range cfg.ImageNotes() {
+		fmt.Fprintln(os.Stderr, note)
+	}
+
 	plat := platform.Detect()
 	dockerClient := docker.NewClient()
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -54,7 +54,9 @@ func newConfigCmd(a *app.App) *cobra.Command {
 			Short: "Reset configuration to defaults",
 			RunE: func(cmd *cobra.Command, args []string) error {
 				defaults := config.DefaultSystemConfig()
-				defaults.Save()
+				if err := defaults.Save(); err != nil {
+					return err
+				}
 				fmt.Println(styles.SuccessStyle.Render("Configuration reset to defaults"))
 				return nil
 			},

--- a/internal/cli/dns.go
+++ b/internal/cli/dns.go
@@ -235,7 +235,7 @@ func dnsStart(ctx context.Context, a *app.App, pull bool) error {
 		steps.Info(meta.Summary(a.DNS.Image()))
 	}
 
-	steps.Run("Clean up existing container", func() error {
+	_ = steps.Run("Clean up existing container", func() error {
 		a.DNS.Cleanup(ctx)
 		return nil
 	})
@@ -283,7 +283,7 @@ func dnsStart(ctx context.Context, a *app.App, pull bool) error {
 		return err
 	}
 
-	steps.Run("Configure wildcard TLDs", func() error {
+	_ = steps.Run("Configure wildcard TLDs", func() error {
 		a.DNS.ConfigureTLDs(ctx)
 		a.DNS.Reload(ctx)
 		return nil
@@ -346,7 +346,7 @@ func quickPing(target string) string {
 		}
 		return styles.WarningStyle.Render("resolved but port 80 unreachable")
 	}
-	conn.Close()
+	_ = conn.Close()
 	elapsed := time.Since(start)
 	return styles.SuccessStyle.Render(fmt.Sprintf("ok (%s)", elapsed.Round(time.Millisecond)))
 }
@@ -362,7 +362,7 @@ func newDNSLogsCmd(a *app.App) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			defer reader.Close()
+			defer func() { _ = reader.Close() }()
 			_, err = io.Copy(os.Stdout, reader)
 			return err
 		},

--- a/internal/cli/proxy.go
+++ b/internal/cli/proxy.go
@@ -37,7 +37,7 @@ func newProxyCmd(a *app.App) *cobra.Command {
 			ctx := context.Background()
 
 			steps := components.NewSteps("🔀", "Stopping Reverse Proxy")
-			steps.Run("Stop proxy container", func() error {
+			_ = steps.Run("Stop proxy container", func() error {
 				res, _ := a.Proxy.StopProxy(ctx)
 				if !res.Found {
 					steps.Info("Proxy container not found")
@@ -46,7 +46,7 @@ func newProxyCmd(a *app.App) *cobra.Command {
 				}
 				return nil
 			})
-			steps.Run("Stop config-gen container", func() error {
+			_ = steps.Run("Stop config-gen container", func() error {
 				res, _ := a.Proxy.StopConfigGen(ctx)
 				if !res.Found {
 					steps.Info("Config-gen container not found")
@@ -69,7 +69,7 @@ func newProxyCmd(a *app.App) *cobra.Command {
 			ctx := context.Background()
 			steps := components.NewSteps("🔀", "Stopping Reverse Proxy")
 
-			steps.Run("Stop proxy container", func() error {
+			_ = steps.Run("Stop proxy container", func() error {
 				res, _ := a.Proxy.StopProxy(ctx)
 				if !res.Found {
 					steps.Info("Proxy container not found")
@@ -78,7 +78,7 @@ func newProxyCmd(a *app.App) *cobra.Command {
 				}
 				return nil
 			})
-			steps.Run("Stop config-gen container", func() error {
+			_ = steps.Run("Stop config-gen container", func() error {
 				res, _ := a.Proxy.StopConfigGen(ctx)
 				if !res.Found {
 					steps.Info("Config-gen container not found")
@@ -215,7 +215,7 @@ func newProxyLogsCmd(a *app.App) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			defer reader.Close()
+			defer func() { _ = reader.Close() }()
 			_, err = io.Copy(os.Stdout, reader)
 			return err
 		},
@@ -247,7 +247,7 @@ func proxyStart(ctx context.Context, a *app.App, pull bool) error {
 		steps.Info(meta.Summary(a.Proxy.Image()))
 	}
 
-	steps.Run("Clean up existing containers", func() error {
+	_ = steps.Run("Clean up existing containers", func() error {
 		a.Proxy.Cleanup(ctx)
 		return nil
 	})

--- a/internal/cli/system.go
+++ b/internal/cli/system.go
@@ -42,12 +42,12 @@ func newRestartCmd(a *app.App) *cobra.Command {
 
 			// Stop proxy first, then DNS.
 			steps := components.NewSteps("🔀", "Stopping Reverse Proxy")
-			steps.Run("Stop proxy container", func() error {
-				a.Proxy.StopProxy(ctx)
+			_ = steps.Run("Stop proxy container", func() error {
+				_, _ = a.Proxy.StopProxy(ctx)
 				return nil
 			})
-			steps.Run("Stop config-gen container", func() error {
-				a.Proxy.StopConfigGen(ctx)
+			_ = steps.Run("Stop config-gen container", func() error {
+				_, _ = a.Proxy.StopConfigGen(ctx)
 				return nil
 			})
 			steps.Done()
@@ -78,7 +78,7 @@ func newStopCmd(a *app.App) *cobra.Command {
 			ctx := context.Background()
 
 			steps := components.NewSteps("🔀", "Stopping Reverse Proxy")
-			steps.Run("Stop proxy container", func() error {
+			_ = steps.Run("Stop proxy container", func() error {
 				res, _ := a.Proxy.StopProxy(ctx)
 				if !res.Found {
 					steps.Info("Proxy container not found")
@@ -87,7 +87,7 @@ func newStopCmd(a *app.App) *cobra.Command {
 				}
 				return nil
 			})
-			steps.Run("Stop config-gen container", func() error {
+			_ = steps.Run("Stop config-gen container", func() error {
 				res, _ := a.Proxy.StopConfigGen(ctx)
 				if !res.Found {
 					steps.Info("Config-gen container not found")

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -1,5 +1,26 @@
 package config
 
+// The images ddt runs, resolved to immutable digests when a release is built.
+//
+// A release stamps these via ldflags with the digest each image had at build time, so a
+// given ddt binary always runs exactly the components it was released against:
+//
+//	-X …/internal/config.ProxyImage=ghcr.io/antimatter-studios/docker-proxy@sha256:…
+//
+// `:latest` remains the default so a build from source keeps working, but it is not
+// what ships. Floating tags meant two components that are only correct TOGETHER could
+// be mixed: a proxy image expecting a template variable its generator does not supply
+// yet, for instance, which produced an nginx config that would not load.
+//
+// The digest pinned is the manifest LIST digest, so it still resolves per architecture.
+// A user hacking on one of these components can point the config file at a local tag —
+// this is a default, not a lock.
+var (
+	DNSImage       = "ghcr.io/antimatter-studios/docker-dns:latest"
+	ProxyImage     = "ghcr.io/antimatter-studios/docker-proxy:latest"
+	ConfigGenImage = "ghcr.io/antimatter-studios/docker-config-gen:latest"
+)
+
 // DefaultSystemConfig returns the default system configuration.
 func DefaultSystemConfig() *SystemConfig {
 	return &SystemConfig{
@@ -8,17 +29,17 @@ func DefaultSystemConfig() *SystemConfig {
 		Version:     CurrentVersion,
 		IPAddress:   "10.254.254.254",
 		DNS: DNSConfig{
-			DockerImage:   "ghcr.io/antimatter-studios/docker-dns:latest",
+			DockerImage:   DNSImage,
 			ContainerName: "ddt-dns",
 			Port:          10053,
 			Upstream:      []string{},
 		},
 		Proxy: ProxyConfig{
-			DockerImage:   "ghcr.io/antimatter-studios/docker-proxy:latest",
+			DockerImage:   ProxyImage,
 			ContainerName: "ddt-proxy",
 		},
 		ConfigGen: ConfigGenConfig{
-			DockerImage:   "ghcr.io/antimatter-studios/docker-config-gen:latest",
+			DockerImage:   ConfigGenImage,
 			ContainerName: "ddt-config-gen",
 		},
 		Projects: ProjectsConfig{

--- a/internal/config/images.go
+++ b/internal/config/images.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ReconcileImage decides which image reference a service should use on startup.
+//
+// The build args say which images THIS ddt is compatible with: a release stamps the
+// digest each component had when it was built, so a binary always runs the components
+// it was released against. That matters because some pairs are only correct together —
+// a proxy image whose template expects a value its generator does not yet supply
+// renders a config nginx will not load.
+//
+// The config file is where that lands, and the rule is: the binary wins, unless the
+// file says the image is the user's own.
+//
+//	"proxy": {
+//	    "docker_image": "ghcr.io/…/docker-proxy:my-local-build",
+//	    "custom_image": true          ← ddt leaves it alone
+//	}
+//
+// Without that flag an edited value is replaced, so the returned note exists to make
+// the replacement visible rather than silent — the failure people actually hit is
+// editing docker_image, forgetting the flag, and wondering why their image stopped
+// being used.
+//
+// next is the reference to use; note is empty unless something changed.
+func ReconcileImage(service, current, expected string, custom bool) (next, note string) {
+	switch {
+	case custom:
+		// Declared as the user's own: never touched, whatever the binary expects.
+		return current, ""
+	case expected == "":
+		// Nothing stamped — a build from source. Leave the file as it is rather than
+		// blanking a working configuration.
+		return current, ""
+	case current == expected:
+		return current, ""
+	case current == "":
+		return expected, ""
+	default:
+		return expected, fmt.Sprintf(
+			"%s: replaced docker_image (was %s) with %s — add \"custom_image\": true beside it to keep your own",
+			service, shortRef(current), shortRef(expected))
+	}
+}
+
+// shortRef abbreviates an image reference for display. A digest-pinned ghcr.io
+// reference is ~110 characters, so a note naming two of them wraps several times in a
+// terminal and buries the one thing it is trying to say. The registry and org are
+// identical across every image ddt runs, and 12 hex digits identify a digest as well
+// here as they do in git.
+//
+// Only for messages — the config file always records the full reference, which is what
+// docker is given and what anyone editing it needs to see.
+func shortRef(ref string) string {
+	short := ref
+	if i := strings.LastIndex(short, "/"); i >= 0 {
+		short = short[i+1:]
+	}
+	if i := strings.Index(short, "@sha256:"); i >= 0 {
+		if hex := short[i+len("@sha256:"):]; len(hex) > 12 {
+			short = short[:i] + "@sha256:" + hex[:12]
+		}
+	}
+	return short
+}

--- a/internal/config/images_test.go
+++ b/internal/config/images_test.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReconcileImage(t *testing.T) {
+	const (
+		expected = "ghcr.io/antimatter-studios/docker-proxy@sha256:aaa"
+		older    = "ghcr.io/antimatter-studios/docker-proxy@sha256:bbb"
+	)
+
+	// The case this whole mechanism exists for: a config written by an older ddt
+	// keeps whatever it recorded, so a binary that pins digests would still run
+	// :latest for every existing user unless startup replaces it.
+	t.Run("a stale value is replaced and reported", func(t *testing.T) {
+		next, note := ReconcileImage("proxy", "ghcr.io/antimatter-studios/docker-proxy:latest", expected, false)
+		if next != expected {
+			t.Errorf("next = %q, want the binary's %q", next, expected)
+		}
+		if note == "" {
+			t.Error("replacement was silent; it must say what it did")
+		}
+	})
+
+	// Editing docker_image and forgetting the flag is the mistake people make, so the
+	// note has to name the flag that prevents it.
+	t.Run("the note explains how to keep a custom image", func(t *testing.T) {
+		_, note := ReconcileImage("proxy", "my-local-build", expected, false)
+		if note == "" {
+			t.Fatal("no note")
+		}
+		// Abbreviated, but the distinguishing part of each reference survives — the
+		// note is useless if it cannot say which image replaced which.
+		for _, want := range []string{"custom_image", "my-local-build", "docker-proxy@sha256:aaa"} {
+			if !strings.Contains(note, want) {
+				t.Errorf("note %q does not mention %q", note, want)
+			}
+		}
+	})
+
+	t.Run("custom_image is never touched", func(t *testing.T) {
+		next, note := ReconcileImage("proxy", "my-local-build", expected, true)
+		if next != "my-local-build" {
+			t.Errorf("next = %q, want the user's own image", next)
+		}
+		if note != "" {
+			t.Errorf("note = %q, want silence when nothing changed", note)
+		}
+	})
+
+	// A build from source stamps nothing. Blanking a working configuration because
+	// the binary has no opinion would be worse than leaving it alone.
+	t.Run("an unstamped build leaves the config alone", func(t *testing.T) {
+		next, note := ReconcileImage("proxy", older, "", false)
+		if next != older || note != "" {
+			t.Errorf("next = %q note = %q, want the existing value untouched", next, note)
+		}
+	})
+
+	// A real digest reference is ~110 characters, so a note naming two of them is a
+	// ~230-character line that wraps several times and hides its own point.
+	t.Run("a note stays readable with real-length references", func(t *testing.T) {
+		const (
+			latest = "ghcr.io/antimatter-studios/docker-proxy:latest"
+			digest = "ghcr.io/antimatter-studios/docker-proxy@sha256:" +
+				"9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+		)
+		_, note := ReconcileImage("proxy", latest, digest, false)
+		// Two 80-column lines. The guard is against the unabbreviated form, which is
+		// ~230 characters; it is not a budget for the wording.
+		if len(note) > 160 {
+			t.Errorf("note is %d chars, too long to read in a terminal:\n%s", len(note), note)
+		}
+		if strings.Contains(note, "9f86d081884c7d659a2") {
+			t.Errorf("full digest was not abbreviated:\n%s", note)
+		}
+		for _, want := range []string{"proxy:", "docker-proxy:latest", "docker-proxy@sha256:9f86d0818", "custom_image"} {
+			if !strings.Contains(note, want) {
+				t.Errorf("note %q does not mention %q", note, want)
+			}
+		}
+	})
+
+	t.Run("no change means no note", func(t *testing.T) {
+		if _, note := ReconcileImage("proxy", expected, expected, false); note != "" {
+			t.Errorf("note = %q, want none", note)
+		}
+	})
+
+	t.Run("an empty config takes the expected value quietly", func(t *testing.T) {
+		next, note := ReconcileImage("proxy", "", expected, false)
+		if next != expected {
+			t.Errorf("next = %q, want %q", next, expected)
+		}
+		if note != "" {
+			t.Errorf("note = %q — filling a blank is not a replacement worth reporting", note)
+		}
+	})
+}

--- a/internal/config/system.go
+++ b/internal/config/system.go
@@ -19,11 +19,24 @@ type SystemConfig struct {
 
 	// path is the file this config was loaded from.
 	path string
+
+	// imageNotes records any docker_image the load reconciled, for the caller to
+	// report. Replacing a value silently is how someone loses a local image build
+	// without ever being told which one.
+	imageNotes []string
 }
+
+// ImageNotes returns a line per docker_image that loading brought into line with this
+// binary's pinned digests. Empty unless something changed.
+func (c *SystemConfig) ImageNotes() []string { return c.imageNotes }
 
 // DNSConfig holds DNS server container settings.
 type DNSConfig struct {
-	DockerImage   string   `json:"docker_image"`
+	DockerImage string `json:"docker_image"`
+	// CustomImage marks DockerImage as the user's own, so ddt leaves it alone instead
+	// of reconciling it against the digest this binary was built with. Additive and
+	// absent by default: a missing key decodes to false, which is the wanted default.
+	CustomImage   bool     `json:"custom_image,omitempty"`
 	ContainerName string   `json:"container_name"`
 	Port          int      `json:"port,omitempty"`
 	TLDs          []string `json:"tlds,omitempty"`
@@ -43,20 +56,24 @@ func (d *DNSConfig) PortOrDefault() int {
 
 // ProxyConfig holds reverse proxy container settings.
 type ProxyConfig struct {
-	DockerImage   string `json:"docker_image"`
+	DockerImage string `json:"docker_image"`
+	// CustomImage: see DNSConfig.CustomImage.
+	CustomImage   bool   `json:"custom_image,omitempty"`
 	ContainerName string `json:"container_name"`
 }
 
 // ConfigGenConfig holds the config generator container settings.
 type ConfigGenConfig struct {
-	DockerImage   string `json:"docker_image"`
+	DockerImage string `json:"docker_image"`
+	// CustomImage: see DNSConfig.CustomImage.
+	CustomImage   bool   `json:"custom_image,omitempty"`
 	ContainerName string `json:"container_name"`
 }
 
 // ProjectsConfig holds project path and list configuration.
 type ProjectsConfig struct {
-	Paths map[string]string         `json:"paths"`
-	List  map[string]ProjectEntry   `json:"list"`
+	Paths map[string]string       `json:"paths"`
+	List  map[string]ProjectEntry `json:"list"`
 }
 
 // ProjectEntry represents a single project in the system config.
@@ -102,7 +119,37 @@ func LoadOrDefault() *SystemConfig {
 
 	cfg.path = path
 	cfg.migrateDomainsTLDs()
+	cfg.reconcileImages()
 	return cfg
+}
+
+// reconcileImages brings each service's docker_image into line with the digests this
+// binary was built against, and persists the result.
+//
+// It runs on every load because the config file outlives the binary: a config written by
+// an older ddt records whatever that version used — usually `:latest` — so without this
+// a release that pins digests would still run floating images for every existing user.
+// Blocks marked custom_image are left alone. See ReconcileImage.
+func (c *SystemConfig) reconcileImages() {
+	changed := false
+	reconcile := func(service string, current *string, expected string, custom bool) {
+		next, note := ReconcileImage(service, *current, expected, custom)
+		if next != *current {
+			*current = next
+			changed = true
+		}
+		if note != "" {
+			c.imageNotes = append(c.imageNotes, note)
+		}
+	}
+
+	reconcile("dns", &c.DNS.DockerImage, DNSImage, c.DNS.CustomImage)
+	reconcile("proxy", &c.Proxy.DockerImage, ProxyImage, c.Proxy.CustomImage)
+	reconcile("config_gen", &c.ConfigGen.DockerImage, ConfigGenImage, c.ConfigGen.CustomImage)
+
+	if changed {
+		_ = c.Save()
+	}
 }
 
 // migrateDomainsTLDs converts any legacy per-domain entries into wildcard TLDs
@@ -125,7 +172,6 @@ func (c *SystemConfig) migrateDomainsTLDs() {
 			if tld != "" && !existing[tld] {
 				c.DNS.TLDs = append(c.DNS.TLDs, tld)
 				existing[tld] = true
-				changed = true
 			}
 		}
 	}

--- a/internal/config/system_images_test.go
+++ b/internal/config/system_images_test.go
@@ -1,0 +1,144 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeConfig puts a system config on disk in an isolated XDG dir and points
+// ConfigPath() at it, so LoadOrDefault can be exercised without touching ~/.config.
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	path := filepath.Join(dir, ConfigDirName, SystemConfigFilename)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func reload(t *testing.T, path string) map[string]map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		// The file also holds non-object keys (version, ip_address); decode loosely.
+		var loose map[string]any
+		if err2 := json.Unmarshal(data, &loose); err2 != nil {
+			t.Fatalf("saved config is not valid JSON: %v", err2)
+		}
+		raw = map[string]map[string]any{}
+		for k, v := range loose {
+			if m, ok := v.(map[string]any); ok {
+				raw[k] = m
+			}
+		}
+	}
+	return raw
+}
+
+// The whole point of pinning: a config written by an older ddt records `:latest`, and
+// unless loading corrects it a release that pins digests still runs floating images for
+// everyone who already has a config file.
+func TestLoadReplacesStaleImages(t *testing.T) {
+	stale := "ghcr.io/antimatter-studios/docker-proxy:latest"
+	pinned := "ghcr.io/antimatter-studios/docker-proxy@sha256:" +
+		"9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+
+	old := ProxyImage
+	ProxyImage = pinned
+	t.Cleanup(func() { ProxyImage = old })
+
+	path := writeConfig(t, `{
+	  "type": "system", "version": "`+CurrentVersion+`", "ip_address": "10.254.254.254",
+	  "dns":        {"docker_image": "`+DNSImage+`", "container_name": "ddt-dns"},
+	  "proxy":      {"docker_image": "`+stale+`", "container_name": "ddt-proxy"},
+	  "config_gen": {"docker_image": "`+ConfigGenImage+`", "container_name": "ddt-config-gen"}
+	}`)
+
+	cfg := LoadOrDefault()
+	if cfg.Proxy.DockerImage != pinned {
+		t.Errorf("in-memory proxy image = %q, want the pinned %q", cfg.Proxy.DockerImage, pinned)
+	}
+	if len(cfg.ImageNotes()) != 1 {
+		t.Errorf("ImageNotes() = %v, want exactly one note about proxy", cfg.ImageNotes())
+	}
+
+	// Persisted, not just corrected in memory — otherwise every run re-reports it.
+	saved := reload(t, path)
+	if got := saved["proxy"]["docker_image"]; got != pinned {
+		t.Errorf("saved proxy image = %v, want %q", got, pinned)
+	}
+	// An untouched service must not gain a custom_image key: the field is additive and
+	// ddt writing it would make every config claim its images are user-owned.
+	if _, ok := saved["dns"]["custom_image"]; ok {
+		t.Errorf("ddt wrote custom_image into a block it did not need to: %v", saved["dns"])
+	}
+}
+
+func TestLoadRespectsCustomImage(t *testing.T) {
+	old := ProxyImage
+	ProxyImage = "ghcr.io/antimatter-studios/docker-proxy@sha256:aaa"
+	t.Cleanup(func() { ProxyImage = old })
+
+	path := writeConfig(t, `{
+	  "type": "system", "version": "`+CurrentVersion+`", "ip_address": "10.254.254.254",
+	  "dns":        {"docker_image": "`+DNSImage+`", "container_name": "ddt-dns"},
+	  "proxy":      {"docker_image": "my-local-proxy:dev", "custom_image": true, "container_name": "ddt-proxy"},
+	  "config_gen": {"docker_image": "`+ConfigGenImage+`", "container_name": "ddt-config-gen"}
+	}`)
+
+	cfg := LoadOrDefault()
+	if cfg.Proxy.DockerImage != "my-local-proxy:dev" {
+		t.Errorf("custom image was overwritten: %q", cfg.Proxy.DockerImage)
+	}
+	if len(cfg.ImageNotes()) != 0 {
+		t.Errorf("ImageNotes() = %v, want none — nothing was changed", cfg.ImageNotes())
+	}
+
+	saved := reload(t, path)
+	if got := saved["proxy"]["docker_image"]; got != "my-local-proxy:dev" {
+		t.Errorf("saved proxy image = %v, want the user's own", got)
+	}
+	if got := saved["proxy"]["custom_image"]; got != true {
+		t.Errorf("custom_image did not survive a save: %v", got)
+	}
+}
+
+// A build from source stamps nothing, so every image is the plain `:latest` default and
+// there is nothing to reconcile. Rewriting the file on every such run would churn it.
+func TestLoadFromSourceBuildLeavesConfigAlone(t *testing.T) {
+	body := `{
+	  "type": "system", "version": "` + CurrentVersion + `", "ip_address": "10.254.254.254",
+	  "dns":        {"docker_image": "` + DNSImage + `", "container_name": "ddt-dns"},
+	  "proxy":      {"docker_image": "` + ProxyImage + `", "container_name": "ddt-proxy"},
+	  "config_gen": {"docker_image": "` + ConfigGenImage + `", "container_name": "ddt-config-gen"}
+	}`
+	path := writeConfig(t, body)
+
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := LoadOrDefault()
+	if len(cfg.ImageNotes()) != 0 {
+		t.Errorf("ImageNotes() = %v, want none", cfg.ImageNotes())
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("config was rewritten with nothing to change:\n%s", strings.TrimSpace(string(after)))
+	}
+}

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -8,13 +8,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/docker/api/types"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/errdefs"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -65,7 +64,7 @@ func (c *Client) HasImage(ctx context.Context, ref string) bool {
 	if err != nil {
 		return false
 	}
-	_, _, err = api.ImageInspectWithRaw(ctx, ref)
+	_, err = api.ImageInspect(ctx, ref)
 	return err == nil
 }
 
@@ -76,7 +75,7 @@ func (c *Client) ImageID(ctx context.Context, ref string) string {
 	if err != nil {
 		return ""
 	}
-	inspect, _, err := api.ImageInspectWithRaw(ctx, ref)
+	inspect, err := api.ImageInspect(ctx, ref)
 	if err != nil {
 		return ""
 	}
@@ -100,7 +99,7 @@ func (c *Client) ImageInfo(ctx context.Context, ref string) *ImageMeta {
 	if err != nil {
 		return nil
 	}
-	inspect, _, err := api.ImageInspectWithRaw(ctx, ref)
+	inspect, err := api.ImageInspect(ctx, ref)
 	if err != nil {
 		return nil
 	}
@@ -132,7 +131,7 @@ func (c *Client) PullImage(ctx context.Context, ref string) error {
 	if err != nil {
 		return fmt.Errorf("pulling image %s: %w", ref, err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 	_, _ = io.Copy(io.Discard, reader)
 	return nil
 }
@@ -142,14 +141,14 @@ func (c *Client) PullImage(ctx context.Context, ref string) error {
 func (c *Client) EnsureImage(ctx context.Context, ref string, forcePull bool, w io.Writer) error {
 	if forcePull {
 		if w != nil {
-			fmt.Fprintf(w, "Pulling image %s ...\n", ref)
+			_, _ = fmt.Fprintf(w, "Pulling image %s ...\n", ref)
 		}
 		return c.PullImage(ctx, ref)
 	}
 
 	if !c.HasImage(ctx, ref) {
 		if w != nil {
-			fmt.Fprintf(w, "Image %s not found locally, pulling ...\n", ref)
+			_, _ = fmt.Fprintf(w, "Image %s not found locally, pulling ...\n", ref)
 		}
 		return c.PullImage(ctx, ref)
 	}
@@ -223,7 +222,7 @@ func (c *Client) StopAndRemoveContainerWithReport(ctx context.Context, nameOrID 
 	info, err := api.ContainerInspect(ctx, nameOrID)
 	if err != nil {
 		// Treat not-found as a non-error; caller can decide what to print.
-		if errdefs.IsNotFound(err) || strings.Contains(err.Error(), "No such container") {
+		if cerrdefs.IsNotFound(err) || strings.Contains(err.Error(), "No such container") {
 			return StopRemoveResult{Found: false}, nil
 		}
 		return StopRemoveResult{}, fmt.Errorf("inspecting container %s: %w", nameOrID, err)
@@ -240,7 +239,7 @@ func (c *Client) StopAndRemoveContainerWithReport(ctx context.Context, nameOrID 
 
 	if err := c.RemoveContainer(ctx, nameOrID, true); err != nil {
 		// If it disappears between inspect and remove, treat as removed.
-		if errdefs.IsNotFound(err) || strings.Contains(err.Error(), "No such container") {
+		if cerrdefs.IsNotFound(err) || strings.Contains(err.Error(), "No such container") {
 			res.Removed = true
 			return res, nil
 		}
@@ -447,7 +446,7 @@ func (c *Client) InspectContainer(ctx context.Context, nameOrID string) (*Contai
 
 	// Fetch image metadata for ID and build date.
 	var imageID, imageCreated string
-	imgInspect, _, err := api.ImageInspectWithRaw(ctx, info.Image)
+	imgInspect, err := api.ImageInspect(ctx, info.Image)
 	if err == nil {
 		imageID = imgInspect.ID
 		imageCreated = imgInspect.Created
@@ -488,7 +487,7 @@ func (c *Client) ListContainersOnNetwork(ctx context.Context, networkName string
 }
 
 // ListRunningContainers returns all running containers, optionally filtered by labels.
-func (c *Client) ListRunningContainers(ctx context.Context, labelFilter ...string) ([]types.Container, error) {
+func (c *Client) ListRunningContainers(ctx context.Context, labelFilter ...string) ([]container.Summary, error) {
 	api, err := c.connect()
 	if err != nil {
 		return nil, err

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -49,7 +49,7 @@ func CheckPortAvailable(ip string, port int) error {
 	if err != nil {
 		return fmt.Errorf("TCP port %d on %s is already in use", port, ip)
 	}
-	ln.Close()
+	_ = ln.Close()
 
 	// Check UDP.
 	ua, err := net.ResolveUDPAddr("udp", addr)
@@ -60,7 +60,7 @@ func CheckPortAvailable(ip string, port int) error {
 	if err != nil {
 		return fmt.Errorf("UDP port %d on %s is already in use", port, ip)
 	}
-	conn.Close()
+	_ = conn.Close()
 
 	return nil
 }

--- a/internal/service/ip.go
+++ b/internal/service/ip.go
@@ -60,6 +60,6 @@ func (s *IPService) Ping() (time.Duration, error) {
 			return 0, fmt.Errorf("host %s unreachable: %w", s.config.IPAddress, err)
 		}
 	}
-	conn.Close()
+	_ = conn.Close()
 	return time.Since(start), nil
 }

--- a/internal/service/probe.go
+++ b/internal/service/probe.go
@@ -45,7 +45,7 @@ func ProbeServices(entries []ProxyStatusEntry) []ProbeResult {
 				results[idx] = ProbeResult{Status: "error"}
 				return
 			}
-			resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 			results[idx] = ProbeResult{
 				StatusCode: resp.StatusCode,
 				Status:     fmt.Sprintf("%d", resp.StatusCode),

--- a/internal/service/proxy.go
+++ b/internal/service/proxy.go
@@ -1,13 +1,10 @@
 package service
 
 import (
-	"archive/tar"
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
@@ -29,14 +26,13 @@ const (
 
 // ProxyService manages the reverse proxy and config-gen containers.
 type ProxyService struct {
-	config   *config.SystemConfig
-	docker   *docker.Client
-	toolsDir string // directory containing proxy-config/
+	config *config.SystemConfig
+	docker *docker.Client
 }
 
 // NewProxyService creates a new proxy service.
-func NewProxyService(cfg *config.SystemConfig, d *docker.Client, toolsDir string) *ProxyService {
-	return &ProxyService{config: cfg, docker: d, toolsDir: toolsDir}
+func NewProxyService(cfg *config.SystemConfig, d *docker.Client) *ProxyService {
+	return &ProxyService{config: cfg, docker: d}
 }
 
 // ProxyStopReport contains the stop/remove results for proxy and config-gen.
@@ -68,8 +64,11 @@ type ProxyStartReport struct {
 	ProxyStarted     bool
 }
 
-// Start launches the config-gen container, then the proxy container, connects
-// them to all configured networks, and copies the nginx config files in.
+// Start launches the config-gen container, then the proxy container.
+//
+// It no longer copies nginx configuration in: the generator writes the config, and
+// proxy.conf ships inside the proxy image. Network connections are managed
+// dynamically by the generator too.
 func (s *ProxyService) Start(ctx context.Context, pull bool) error {
 	_, err := s.StartWithReport(ctx, pull)
 	return err
@@ -98,16 +97,11 @@ func (s *ProxyService) StartWithReport(ctx context.Context, pull bool) (ProxySta
 	report.ConfigGenStarted = true
 
 	// 2. Start the proxy (nginx).
-	proxyID, err := s.startProxy(ctx)
+	_, err = s.startProxy(ctx)
 	if err != nil {
 		return report, fmt.Errorf("starting proxy: %w", err)
 	}
 	report.ProxyStarted = true
-
-	// 3. Copy nginx config files into the proxy container.
-	if err := s.copyProxyConfigs(ctx, proxyID); err != nil {
-		return report, fmt.Errorf("copying proxy configs: %w", err)
-	}
 
 	return report, nil
 }
@@ -380,15 +374,11 @@ func (s *ProxyService) StartConfigGenContainer(ctx context.Context) error {
 	return err
 }
 
-// StartProxyContainer creates and starts the proxy container and copies
-// the nginx configuration files. Network connections are managed dynamically
-// by docker-config-gen.
+// StartProxyContainer creates and starts the proxy container.
+// Network connections are managed dynamically by docker-config-gen.
 func (s *ProxyService) StartProxyContainer(ctx context.Context) error {
-	proxyID, err := s.startProxy(ctx)
-	if err != nil {
-		return err
-	}
-	return s.copyProxyConfigs(ctx, proxyID)
+	_, err := s.startProxy(ctx)
+	return err
 }
 
 // ConfigGenContainerName returns the configured config-gen container name.
@@ -451,39 +441,3 @@ func (s *ProxyService) startProxy(ctx context.Context) (string, error) {
 	)
 }
 
-func (s *ProxyService) copyProxyConfigs(ctx context.Context, containerID string) error {
-	files := map[string]string{
-		filepath.Join(s.toolsDir, "proxy-config", "global.conf"):      "/etc/nginx/conf.d/global.conf",
-		filepath.Join(s.toolsDir, "proxy-config", "nginx-proxy.conf"): "/etc/nginx/proxy.conf",
-	}
-
-	for src, dest := range files {
-		if err := s.copyFileToContainer(ctx, containerID, src, dest); err != nil {
-			return fmt.Errorf("copying %s: %w", filepath.Base(src), err)
-		}
-	}
-	return nil
-}
-
-func (s *ProxyService) copyFileToContainer(ctx context.Context, containerID, srcPath, destPath string) error {
-	data, err := os.ReadFile(srcPath)
-	if err != nil {
-		return err
-	}
-
-	var buf bytes.Buffer
-	tw := tar.NewWriter(&buf)
-	if err := tw.WriteHeader(&tar.Header{
-		Name: filepath.Base(destPath),
-		Mode: 0644,
-		Size: int64(len(data)),
-	}); err != nil {
-		return err
-	}
-	if _, err := tw.Write(data); err != nil {
-		return err
-	}
-	_ = tw.Close()
-
-	return s.docker.CopyToContainer(ctx, containerID, filepath.Dir(destPath), &buf)
-}

--- a/internal/tui/components/logstream.go
+++ b/internal/tui/components/logstream.go
@@ -47,13 +47,13 @@ func startLogStream(d *docker.Client, containerName string, ctx context.Context)
 	ch := make(chan []string, 8)
 
 	go func() {
-		defer reader.Close()
+		defer func() { _ = reader.Close() }()
 		defer close(ch)
 
 		// Demux the Docker multiplexed stream (stdout+stderr) into a single pipe.
 		pr, pw := io.Pipe()
 		go func() {
-			defer pw.Close()
+			defer func() { _ = pw.Close() }()
 			// Merge stdout and stderr into one stream.
 			_, _ = stdcopy.StdCopy(pw, pw, reader)
 		}()

--- a/internal/tui/components/ping.go
+++ b/internal/tui/components/ping.go
@@ -315,7 +315,7 @@ func doPing(target string, seq int) tea.Cmd {
 				}}
 			}
 		}
-		conn.Close()
+		_ = conn.Close()
 
 		return pingResultMsg{result: PingResult{
 			Seq:     seq,

--- a/internal/tui/components/spinner.go
+++ b/internal/tui/components/spinner.go
@@ -97,10 +97,10 @@ func (m OperationModel) View() string {
 				Render(fmt.Sprintf("completed in %s", m.elapsed.Round(time.Millisecond))))
 		}
 	} else {
-		b.WriteString(fmt.Sprintf("%s %s",
+		fmt.Fprintf(&b, "%s %s",
 			m.spinner.View(),
 			lipgloss.NewStyle().Foreground(styles.TextDim).Render(m.title),
-		))
+		)
 		if m.detail != "" {
 			b.WriteString("\n")
 			b.WriteString(lipgloss.NewStyle().PaddingLeft(2).Foreground(styles.Subtle).Render(m.detail))

--- a/internal/tui/components/status.go
+++ b/internal/tui/components/status.go
@@ -235,11 +235,11 @@ func sortSidecarEntries(entries []service.SidecarStatusEntry) {
 
 // DNSTLDData holds the gathered TLD state from all three sources.
 type DNSTLDData struct {
-	AllTLDs      []string
-	InConfig     map[string]bool
-	InContainer  map[string]bool
-	InSystem     map[string]bool
-	DNSRunning   bool
+	AllTLDs     []string
+	InConfig    map[string]bool
+	InContainer map[string]bool
+	InSystem    map[string]bool
+	DNSRunning  bool
 }
 
 // GatherDNSTLDData collects TLD information from config, container, and system resolvers.
@@ -375,10 +375,10 @@ func renderDNSTLDBoxFromApp(a *app.App, ctx context.Context, dnsRunning bool, to
 	rows := buildDNSTLDRows(data)
 
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("%s %s\n",
+	fmt.Fprintf(&b, "%s %s\n",
 		iconStyle.Render("📡"),
 		titleStyle.Render(fmt.Sprintf("DNS TLD Status (%d)", len(data.AllTLDs))),
-	))
+	)
 	b.WriteString(styles.HorizontalRule(innerWidth))
 	b.WriteString("\n")
 	b.WriteString(RenderTable(headers, rows, innerWidth))
@@ -484,10 +484,10 @@ func renderProxyServicesBoxFromEntries(entries []service.ProxyStatusEntry, total
 	rows := buildProxyRows(entries, true)
 
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("%s %s\n",
+	fmt.Fprintf(&b, "%s %s\n",
 		iconStyle.Render("🔀"),
 		titleStyle.Render(fmt.Sprintf("Proxied Services (%d)", len(entries))),
-	))
+	)
 	b.WriteString(styles.HorizontalRule(innerWidth))
 	b.WriteString("\n")
 	b.WriteString(RenderTable(proxyHeaders, rows, innerWidth))
@@ -516,10 +516,10 @@ func renderSidecarServicesBoxFromEntries(entries []service.SidecarStatusEntry, t
 	}
 
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("%s %s\n",
+	fmt.Fprintf(&b, "%s %s\n",
 		iconStyle.Render("🔌"),
 		titleStyle.Render(fmt.Sprintf("TCP/UDP Sidecars (%d)", len(entries))),
-	))
+	)
 	b.WriteString(styles.HorizontalRule(innerWidth))
 	b.WriteString("\n")
 	b.WriteString(RenderTable(sidecarHeaders, rows, innerWidth))
@@ -544,7 +544,6 @@ func FormatHTTPStatus(code int, status string) string {
 		return styles.ErrorStyle.Render(text)
 	}
 }
-
 
 type cardDef struct {
 	icon   string
@@ -711,11 +710,11 @@ func renderCardBody(c cardDef, innerWidth int) string {
 	// Title line.
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(styles.Text)
 	iconStyle := lipgloss.NewStyle().Foreground(styles.Secondary)
-	b.WriteString(fmt.Sprintf("%s %s  %s\n",
+	fmt.Fprintf(&b, "%s %s  %s\n",
 		iconStyle.Render(c.icon),
 		titleStyle.Render(c.title),
 		styles.StatusBadge(c.active),
-	))
+	)
 
 	b.WriteString(styles.HorizontalRule(innerWidth))
 	b.WriteString("\n")
@@ -736,7 +735,7 @@ func renderCardBody(c cardDef, innerWidth int) string {
 			Align(lipgloss.Right).
 			Render(r.Key)
 		val := lipgloss.NewStyle().Foreground(styles.TextDim).Render(r.Value)
-		b.WriteString(fmt.Sprintf("%s  %s\n", label, val))
+		fmt.Fprintf(&b, "%s  %s\n", label, val)
 	}
 
 	return b.String()


### PR DESCRIPTION
ddt ran `ghcr.io/antimatter-studios/docker-{dns,proxy,config-gen}:latest`, so which components a given ddt drove depended on when the user last pulled. That is fine until two of them are only correct together — a proxy image whose template expects a value its generator does not yet supply renders an nginx config that will not load, and nothing in the versions involved says so.

### How it works

A release resolves each image to its **manifest-list digest** (so it still resolves per architecture) and stamps it into the binary via ldflags. A ddt version therefore declares the components it works with. Source builds stamp nothing and keep `:latest`.

The config file outlives the binary, so startup reconciles it. A config written by an older ddt records whatever that version used — usually `:latest` — and without this a release that pins digests would still run floating images for everyone who already has a config file. Each service block is compared against what the binary expects, corrected, and the replacement reported on stderr:

```
proxy: replaced docker_image (was docker-proxy:latest) with docker-proxy@sha256:9f86d081884c — add "custom_image": true beside it to keep your own
```

To keep your own build, add `"custom_image": true` beside `docker_image`:

```json
"proxy": { "docker_image": "my-local-proxy:dev", "custom_image": true }
```

The field is additive: absent decodes to `false`, which is the wanted default, so no existing config needs migrating and ddt never writes the key itself.

### Verified locally

- 11 tests, including the end-to-end cases: a stale `:latest` config is corrected **and persisted**; `custom_image` survives a save untouched; a source build rewrites nothing at all
- a build with the variables unset keeps `:latest` in the binary
- a build with them set has the digests in the binary
- notes stay one readable line — a real digest reference is ~110 characters, so they are abbreviated for display while the config keeps the full value

### Also in here

Separate commits, each independent:

- **docker SDK**: `ImageInspectWithRaw` → `ImageInspect`, `errdefs` → `containerd/errdefs`
- **stop copying nginx config into the proxy container** — the generator writes it and `proxy.conf` ships in the image. It made behaviour depend on a directory sitting next to the executable, which a brew-installed binary does not have.
- **one real bug among the linter fixes**: `ddt config` dropped the error from `defaults.Save()`, so failing to write the config file still reported success
- goreleaser and its action are now pinned; `version: latest` meant an unpinned tool building the binary and writing the Homebrew cask

### Note

`.goreleaser.yml` has a `homebrew_casks:` block, so ddt pushes its cask into the tap using `HOMEBREW_TAP_TOKEN` — the opposite of the pull model the tap uses for everything else. Left alone here; worth a decision separately.