### PR TITLE
Stop writing the Homebrew cask from this repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
-          # Pinned, not `latest`: goreleaser builds the binary users install and writes
-          # the Homebrew cask, so it is part of the supply chain.
+          # Pinned, not `latest`: goreleaser builds the binary users install, so it is
+          # part of the supply chain. It no longer writes the Homebrew cask.
           version: v2.17.0
           args: release --clean
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,5 +56,6 @@ jobs:
           version: v2.17.0
           args: release --clean
         env:
+          # Only this repository's own releases. Nothing here can write to the Homebrew
+          # tap any more — see the note in .goreleaser.yml.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,19 +44,19 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
-homebrew_casks:
-  - name: ddt
-    binaries:
-      - ddt
-    repository:
-      owner: antimatter-studios
-      name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    homepage: https://github.com/antimatter-studios/docker-dev-tools
-    description: "Docker development tools CLI"
-    hooks:
-      post:
-        install: 'system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/ddt"]'
+# No `homebrew_casks:` block here, deliberately.
+#
+# goreleaser can write the cask straight into antimatter-studios/homebrew-tap, and this
+# release used to do exactly that with a token that had write access to the tap. That
+# means a release from this repository could change what `brew install ddt` fetches,
+# with nothing between the two.
+#
+# The tap is a PULL consumer instead, as it is for every other project in it: its "Sync
+# formulae from releases" workflow reads this repository's public releases, hashes the
+# assets it downloaded, and pushes a branch. A person opens the PR and merges it.
+#
+# To publish a release to brew: run that workflow in the tap, then open and merge the
+# PR it leaves behind.
 
 changelog:
   sort: asc


### PR DESCRIPTION
`.goreleaser.yml` had a `homebrew_casks:` block that wrote `Casks/ddt.rb` straight into `antimatter-studios/homebrew-tap`, using a token with write access to that repository. A release here could therefore change what `brew install ddt` fetches, with nothing in between — and this repository had to hold a credential for a repository that isn't it.

Every other project in that tap is pulled, not pushed. ddt now matches: the tap reads this repository's public releases, hashes the assets it downloaded, and pushes a branch for a person to open and merge.

Removed here:

- the `homebrew_casks:` block
- `HOMEBREW_TAP_TOKEN` from the release workflow's environment

The tap side is a separate PR, which adds ddt to its `projects.json` and teaches its sync about goreleaser's default asset naming (`ddt_2.1.0_darwin_amd64.tar.gz`) so this project's release artifacts do not have to be renamed.

**Ordering:** nothing breaks in between. The cask stays exactly as it is until the tap side lands; the only change is that a future release will not overwrite it.

**To publish a release to brew from now on:** run "Sync formulae from releases" in the tap, then open and merge the PR it leaves behind.