### PR TITLE
Install github-guard hooks

### DIFF
--- a/.githooks/applypatch-msg
+++ b/.githooks/applypatch-msg
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# github-guard hook: applypatch-msg
+#
+# Fires:    During `git am`, before a mailed patch is committed — to check its message.
+# Use for:  Validating/normalizing commit messages of emailed patches.
+# Blocking: yes (non-zero stops `git am`)
+#
+# Dispatcher: runs every executable script in  .githooks/applypatch-msg.d/  in lexical
+# order. Add behaviour by dropping a guard script there; remove it by deleting
+# the file (or `chmod -x`). No applypatch-msg.d/ (or an empty one) = no-op. Managed by
+# github-guard — edit guards in the .d/ dir, not this file.
+d=$(cd "$(dirname "$0")" && pwd)
+exec "$d/lib/run-guards.sh" "$(basename "$0")" "$@"

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# github-guard hook: commit-msg
+#
+# Fires:    After the commit message is entered, before the commit is finalized.
+# Use for:  Enforcing message format (e.g. Conventional Commits).
+# Blocking: yes (non-zero aborts the commit)
+#
+# Dispatcher: runs every executable script in  .githooks/commit-msg.d/  in lexical
+# order. Add behaviour by dropping a guard script there; remove it by deleting
+# the file (or `chmod -x`). No commit-msg.d/ (or an empty one) = no-op. Managed by
+# github-guard — edit guards in the .d/ dir, not this file.
+d=$(cd "$(dirname "$0")" && pwd)
+exec "$d/lib/run-guards.sh" "$(basename "$0")" "$@"

--- a/.githooks/lib/common.sh
+++ b/.githooks/lib/common.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Shared helpers for github-guard guards. Source this file; it defines
+# functions only and never exits the calling shell.
+#
+# Fail-open by design: a guard that blocks your work because gh/network/perms
+# are unavailable is worse than the mistake it prevents. The local hard-block
+# guards (merge commits) are the exception — they need no network.
+
+# Echo the GitHub "owner/repo" slug for origin, or nothing if origin is missing
+# or not on github.com.
+gg_repo_slug() {
+  local url rest host path
+  url=$(git remote get-url origin 2>/dev/null) || return 0
+  url=${url%.git}
+  case "$url" in
+    ssh://*|https://*|http://*)
+      # scheme://[user@]host[:port]/owner/repo (incl. GitHub SSH-over-443,
+      # ssh://git@ssh.github.com:443/owner/repo).
+      rest=${url#*://}; rest=${rest#*@}
+      host=${rest%%/*}; host=${host%%:*}
+      path=${rest#*/}
+      ;;
+    *:*)
+      # scp-style [user@]host:owner/repo (git@github.com:owner/repo).
+      host=${url%%:*}; host=${host#*@}
+      path=${url#*:}
+      ;;
+    *)
+      return 0 ;;
+  esac
+  # Only claim a slug for a real GitHub host — never a substring match like
+  # https://evil.com/github.com/owner/repo or ssh://git@github.com.example.org/…,
+  # which would otherwise let the GitHub guards act on an unrelated repo.
+  case "$host" in
+    github.com|ssh.github.com) ;;
+    *) return 0 ;;
+  esac
+  printf '%s' "$path"
+}
+
+# True if gh is installed and authenticated.
+gg_have_gh() { command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; }
+
+# Echo the authenticated GitHub login, or nothing.
+gg_login() { gh api user --jq '.login' 2>/dev/null; }
+
+# Return 0 only if the authenticated user OWNS this account: it is their
+# personal account, or an org where their membership role is "admin" (owner).
+# We change settings only on accounts we own — never other people's orgs, even
+# where we happen to have repo-admin. A new org you create matches (you own it).
+gg_user_owns() {
+  local owner="$1" me role
+  me=$(gg_login); [ -n "$me" ] || return 1
+  [ "$owner" = "$me" ] && return 0
+  role=$(gh api "user/memberships/orgs/$owner" --jq '.role' 2>/dev/null) || return 1
+  [ "$role" = "admin" ]
+}
+
+# NOTE: deliberately no throttling. The network guards run only on commit/push
+# — sparse, event-driven, a few calls each, nowhere near the 5000/hour API
+# limit — so the ~1-2s they add to the occasional commit isn't worth a
+# stamp-file/TTL mechanism.
+
+# True if this repo keeps a changelog — a root CHANGELOG.md, or a "Changelog"
+# (release notes / history) section in the root README.md. Guards that enforce
+# changelog discipline self-gate on this: no changelog convention → they no-op,
+# so projects without one are unaffected.
+gg_has_changelog() {
+  local root
+  root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+  [ -f "$root/CHANGELOG.md" ] && return 0
+  [ -f "$root/README.md" ] \
+    && grep -qiE '^#{2,}[[:space:]]+(change ?log|release notes|recent changes|releases|history)\b' "$root/README.md" \
+    && return 0
+  return 1
+}
+
+# --- Rust helpers (shared by the rust-* guards) ------------------------------
+
+# True if the repo root holds a Cargo.toml (i.e. it's a Cargo project).
+gg_is_rust() {
+  local root
+  root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+  [ -f "$root/Cargo.toml" ]
+}
+
+# Run cargo via the rustup SHIM (`~/.cargo/bin/cargo`) so a repo's
+# rust-toolchain.toml pin is honored automatically — local fmt/clippy then use
+# the same toolchain as CI. A bare `cargo` can be Homebrew's, which ignores the
+# pin entirely; the shim is the rustup proxy and respects it (installing the
+# pinned toolchain on first use, as rustup intends). Falls back to whatever
+# `cargo` is on PATH if the shim isn't present; returns 2 if there's no cargo
+# at all (callers treat that as "skip, don't block").
+gg_cargo() {
+  local shim="$HOME/.cargo/bin/cargo"
+  if [ -x "$shim" ]; then
+    "$shim" "$@"
+  elif command -v cargo >/dev/null 2>&1; then
+    cargo "$@"
+  else
+    return 2
+  fi
+}

--- a/.githooks/lib/run-guards.sh
+++ b/.githooks/lib/run-guards.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# github-guard dispatcher (run-parts style). A hook stub invokes it as:
+#
+#   run-guards.sh <hook-name> [hook-args...]      (the hook's stdin is passed through)
+#
+# It runs every executable script in  <.githooks>/<hook-name>.d/  in lexical
+# order, feeding each guard the original hook args and stdin. A guard that
+# exits non-zero blocks the operation: github-guard names the offending guard
+# and stops (later guards don't run). An empty/missing .d directory is a no-op,
+# so a documented stub with no guards costs almost nothing.
+set -u
+
+hook=${1:-}
+[ -n "$hook" ] && shift || { echo "github-guard: run-guards needs a hook name" >&2; exit 0; }
+
+hooks_dir=$(cd "$(dirname "$0")/.." && pwd)
+guard_dir="$hooks_dir/$hook.d"
+
+# Fast no-op: nothing to run unless the .d dir holds at least one executable.
+has_guard=0
+if [ -d "$guard_dir" ]; then
+  for g in "$guard_dir"/*; do
+    if [ -f "$g" ] && [ -x "$g" ]; then has_guard=1; break; fi
+  done
+fi
+[ "$has_guard" = 1 ] || exit 0
+
+# Capture the hook's stdin once so every guard can read it (e.g. pre-push gets
+# the ref list, post-rewrite gets the rewritten commits). Skip when stdin is a
+# TTY (manual run) so we never hang waiting for EOF.
+stdin_file=$(mktemp "${TMPDIR:-/tmp}/gg-stdin.XXXXXX")
+trap 'rm -f "$stdin_file"' EXIT
+if [ -t 0 ]; then : > "$stdin_file"; else cat > "$stdin_file"; fi
+
+for guard in "$guard_dir"/*; do
+  [ -f "$guard" ] && [ -x "$guard" ] || continue
+  if ! "$guard" "$@" < "$stdin_file"; then
+    echo "github-guard: '$(basename "$guard")' blocked '$hook'." >&2
+    echo "             Fix the issue above, or bypass once with:  git ... --no-verify" >&2
+    exit 1
+  fi
+done
+exit 0

--- a/.githooks/post-applypatch
+++ b/.githooks/post-applypatch
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# github-guard hook: post-applypatch
+#
+# Fires:    During `git am`, after the patch has been committed.
+# Use for:  Notifications or follow-up actions after applying a patch.
+# Blocking: no (exit code ignored)
+#
+# Dispatcher: runs every executable script in  .githooks/post-applypatch.d/  in lexical
+# order. Add behaviour by dropping a guard script there; remove it by deleting
+# the file (or `chmod -x`). No post-applypatch.d/ (or an empty one) = no-op. Managed by
+# github-guard — edit guards in the .d/ dir, not this file.
+d=$(cd "$(dirname "$0")" && pwd)
+exec "$d/lib/run-guards.sh" "$(basename "$0")" "$@"

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# github-guard hook: post-checkout
+#
+# Fires:    After `git checkout`/`switch`/`clone` updates the working tree.
+# Use for:  Environment setup, LFS smudge, warnings on branch switch.
+# Blocking: no (exit code ignored)
+#
+# Dispatcher: runs every executable script in  .githooks/post-checkout.d/  in lexical
+# order. Add behaviour by dropping a guard script there; remove it by deleting
+# the file (or `chmod -x`). No post-checkout.d/ (or an empty one) = no-op. Managed by
+# github-guard — edit guards in the .d/ dir, not this file.
+d=$(cd "$(dirname "$0")" && pwd)
+exec "$d/lib/run-guards.sh" "$(basename "$0")" "$@"

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# github-guard hook: post-commit
+#
+# Fires:    Right after a commit is created.
+# Use for:  Notifications, stats, bookkeeping.
+# Blocking: no (exit code ignored)
+#
+# Dispatcher: runs every executable script in  .githooks/post-commit.d/  in lexical
+# order. Add behaviour by dropping a guard script there; remove it by deleting
+# the file (or `chmod -x`). No post-commit.d/ (or an empty one) = no-op. Managed by
+# github-guard — edit guards in the .d/ dir, not this file.
+d=$(cd "$(dirname "$0")" && pwd)
+exec "$d/lib/run-guards.sh" "$(basename "$0")" "$@"

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# github-guard hook: post-merge
+#
+# Fires:    After a `git merge` (or `git pull`) completes.
+# Use for:  Restoring file perms, rebuilding generated files, fetching LFS.
+# Blocking: no (exit code ignored)
+#
+# Dispatcher: runs every executable script in  .githooks/post-merge.d/  in lexical
+# order. Add behaviour by dropping a guard script there; remove it by deleting
+# the file (or `chmod -x`). No post-merge.d/ (or an empty one) = no-op. Managed by
+# github-guard — edit guards in the .d/ dir, not this file.
+d=$(cd "$(dirname "$0")" && pwd)
+exec "$d/lib/run-guards.sh" "$(basename "$0")" "$@"

--- a/.githooks/post-rewrite
+++ b/.githooks/post-rewrite
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# github-guard hook: post-rewrite
+#
+# Fires:    After commits are rewritten (`git rebase`, `git commit --amend`). Rewritten commits arrive on stdin.
+# Use for:  Updating notes/refs that referenced the old commits.
+# Blocking: no (exit code ignored)
+#
+# Dispatcher: runs every executable script in  .githooks/post-rewrite.d/  in lexical
+# order. Add behaviour by dropping a guard script there; remove it by deleting
+# the file (or `chmod -x`). No post-rewrite.d/ (or an empty one) = no-op. Managed by
+# github-guard — edit guards in the .d/ dir, not this file.
+d=$(cd "$(dirname "$0")" && pwd)
+exec "$d/lib/run-guards.sh" "$(basename "$0")" "$@"

--- a/.githooks/pre-applypatch
+++ b/.githooks/pre-applypatch
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# github-guard hook: pre-applypatch
+#
+# Fires:    During `git am`, after the patch is applied to the tree but before committing.
+# Use for:  Inspecting or testing the applied tree before it becomes a commit.
+# Blocking: yes (non-zero stops `git am`)
+#
+# Dispatcher: runs every executable script in  .githooks/pre-applypatch.d/  in lexical
+# order. Add behaviour by dropping a guard script there; remove it by deleting
+# the file (or `chmod -x`). No pre-applypatch.d/ (or an empty one) = no-op. Managed by
+# github-guard — edit guards in the .d/ dir, not this file.
+d=$(cd "$(dirname "$0")" && pwd)
+exec "$d/lib/run-guards.sh" "$(basename "$0")" "$@"

--- a/.githooks/pre-auto-gc
+++ b/.githooks/pre-auto-gc
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# github-guard hook: pre-auto-gc
+#
+# Fires:    Before an automatic `git gc` runs.
+# Use for:  Deferring gc when it would be inconvenient.
+# Blocking: yes (non-zero skips gc this time)
+#
+# Dispatcher: runs every executable script in  .githooks/pre-auto-gc.d/  in lexical
+# order. Add behaviour by dropping a guard script there; remove it by deleting
+# the file (or `chmod -x`). No pre-auto-gc.d/ (or an empty one) = no-op. Managed by
+# github-guard — edit guards in the .d/ dir, not this file.
+d=$(cd "$(dirname "$0")" && pwd)
+exec "$d/lib/run-guards.sh" "$(basename "$0")" "$@"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# github-guard hook: pre-commit
+#
+# Fires:    On `git commit`, before the commit message is requested.
+# Use for:  Linting, formatting, and fast checks on the staged snapshot.
+# Blocking: yes (non-zero aborts the commit)
+#
+# Dispatcher: runs every executable script in  .githooks/pre-commit.d/  in lexical
+# order. Add behaviour by dropping a guard script there; remove it by deleting
+# the file (or `chmod -x`). No pre-commit.d/ (or an empty one) = no-op. Managed by
+# github-guard — edit guards in the .d/ dir, not this file.
+d=$(cd "$(dirname "$0")" && pwd)
+exec "$d/lib/run-guards.sh" "$(basename "$0")" "$@"

--- a/.githooks/pre-commit.d/git-block-bad-files.sh
+++ b/.githooks/pre-commit.d/git-block-bad-files.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# guard: git-block-bad-files
+# Refuse to commit files that almost never belong in a repo and are costly to
+# leak/track: private keys & certs, credential blobs, env files, OS junk, and
+# merge cruft. Matches STAGED files by basename; blocks (exit 1) with an unstage
+# hint.
+#
+# Conservative by design (safe to run in ANY repo): it does NOT match broad
+# words like "secret"/"credential" — plenty of codebases legitimately have
+# files named that way (e.g. a password manager). And env *templates*
+# (.env.example/.sample/.template/.dist) are allowed. For a genuine edge,
+# bypass once with `git commit --no-verify`.
+set -uf   # -f: keep the '*' patterns literal during word-splitting
+
+staged=$(git diff --cached --name-only --diff-filter=ACM)
+[ -n "$staged" ] || exit 0
+
+# Basename glob patterns that are (almost) never intended in a commit.
+patterns='
+.DS_Store
+Thumbs.db
+desktop.ini
+*.pem
+*.key
+*.p12
+*.pfx
+*.keystore
+*.jks
+id_rsa
+id_dsa
+id_ecdsa
+id_ed25519
+*-adminsdk-*.json
+service-account*.json
+*.orig
+*.rej
+'
+
+# .env and .env.<x> are secrets; the conventional templates are not.
+env_is_secret() {
+  case "$1" in
+    .env) return 0 ;;
+    .env.example|.env.sample|.env.template|.env.dist|.env.*.example) return 1 ;;
+    .env.*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+fail=0
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  base=${path##*/}
+  bad=0
+  if env_is_secret "$base"; then
+    bad=1
+  else
+    for pat in $patterns; do
+      case "$base" in $pat) bad=1; break ;; esac
+    done
+  fi
+  if [ "$bad" = 1 ]; then
+    echo "github-guard: refusing to commit '$path' — looks like a key/credential/env/junk file." >&2
+    echo "             unstage it:   git restore --staged \"$path\"" >&2
+    echo "             or bypass once (intentional): git commit --no-verify" >&2
+    fail=1
+  fi
+done <<EOF
+$staged
+EOF
+exit "$fail"

--- a/.githooks/pre-commit.d/git-block-large-files.sh
+++ b/.githooks/pre-commit.d/git-block-large-files.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# guard: git-block-large-files
+# Refuse to commit a staged file larger than the limit (default 10 MiB) unless
+# it's tracked by Git LFS. Big blobs bloat history forever — deleting one later
+# needs a full history rewrite. This is a BACKSTOP for accidents; the right home
+# for genuinely large assets is .gitignore (e.g. *.img, *.qcow2) or Git LFS.
+# Override the limit with GITHUB_GUARD_MAX_FILE_MB. Bypass once: git commit --no-verify.
+set -u
+max_mb=${GITHUB_GUARD_MAX_FILE_MB:-10}
+max_bytes=$(( max_mb * 1024 * 1024 ))
+
+staged=$(git diff --cached --name-only --diff-filter=ACM)
+[ -n "$staged" ] || exit 0
+
+fail=0
+while IFS= read -r path; do
+  [ -n "$path" ] && [ -f "$path" ] || continue
+  # Tracked by Git LFS? Then only a small pointer is committed — allow it.
+  if git check-attr filter -- "$path" 2>/dev/null | grep -q ': filter: lfs$'; then
+    continue
+  fi
+  sz=$(stat -f '%z' "$path" 2>/dev/null || stat -c '%s' "$path" 2>/dev/null || echo 0)
+  if [ "$sz" -gt "$max_bytes" ]; then
+    mb=$(( sz / 1024 / 1024 ))
+    echo "git-block-large-files: '$path' is ${mb} MiB (limit ${max_mb} MiB)." >&2
+    echo "             .gitignore it, track it with Git LFS, or store it outside the repo." >&2
+    echo "             intentional? bypass once: git commit --no-verify" >&2
+    fail=1
+  fi
+done <<EOF
+$staged
+EOF
+exit "$fail"

--- a/.githooks/pre-commit.d/git-no-trailing-whitespace.sh
+++ b/.githooks/pre-commit.d/git-no-trailing-whitespace.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# guard: git-no-trailing-whitespace
+# Block the commit if the staged changes introduce whitespace errors — trailing
+# whitespace, space-before-tab, or a stray blank line at EOF. Uses git's own
+# `diff --cached --check`, which only flags lines THIS commit adds, so
+# pre-existing whitespace in untouched lines never blocks your work.
+set -u
+
+if ! out=$(git diff --cached --check 2>&1); then
+  echo "github-guard: staged changes introduce whitespace errors:" >&2
+  printf '%s\n' "$out" | sed 's/^/  /' >&2
+  echo "             trim them (most editors do on save), or bypass once: git commit --no-verify" >&2
+  exit 1
+fi
+exit 0

--- a/.githooks/pre-commit.d/github-merge-squash-only.sh
+++ b/.githooks/pre-commit.d/github-merge-squash-only.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# guard: github-merge-squash-only
+# Ensure the GitHub repo allows only squash + rebase merges (no merge commits),
+# so PRs always land linear. Owner-only, fail-open — NEVER blocks the commit.
+set -u
+dir=$(cd "$(dirname "$0")/.." && pwd)   # .githooks/
+# shellcheck source=../lib/common.sh
+. "$dir/lib/common.sh"
+
+slug=$(gg_repo_slug); [ -n "$slug" ] || exit 0
+gg_have_gh || { echo "github-guard: gh not installed/authed — skipping merge-settings check for $slug" >&2; exit 0; }
+owner=${slug%%/*}
+gg_user_owns "$owner" || exit 0
+
+# Reconcile the FULL desired state — SQUASH ONLY — whenever any of the three
+# differ. Reading only allow_merge_commit missed the common case of a repo that
+# already has merge commits off but still disallows squash (e.g. rebase-only): the
+# old check saw merge_commit=false and skipped, leaving squash disabled so
+# `gh pr merge --squash` failed.
+#
+# Rebase is off, not merely unused. This guard used to ENFORCE rebase=true, so a
+# repo set to squash-only was silently switched back on the next commit. One commit
+# per pull request is the point: a branch's work-in-progress history is noise once
+# it lands, and the squash message is written deliberately rather than composed by
+# GitHub from whatever the commits happened to say.
+set -- $(gh api "repos/$slug" \
+  --jq '"\(.allow_merge_commit) \(.allow_squash_merge) \(.allow_rebase_merge)"' 2>/dev/null)
+mc=${1:-} sq=${2:-} rb=${3:-}
+# Only act on a well-formed response: each field must be a literal boolean. A
+# missing field makes jq emit "null" (non-empty), and a failed/edge read yields
+# empty — neither must be mistaken for "needs reconciling" and trigger a PATCH.
+for v in "$mc" "$sq" "$rb"; do
+  case "$v" in
+    true|false) ;;
+    *) echo "github-guard: unexpected merge-settings response for $slug — skipping" >&2; exit 0 ;;
+  esac
+done
+
+if [ "$mc" != "false" ] || [ "$sq" != "true" ] || [ "$rb" != "false" ]; then
+  echo "github-guard: $slug merge settings (merge=$mc squash=$sq rebase=$rb) — reconciling to squash only…" >&2
+  if gh api -X PATCH "repos/$slug" \
+       -F allow_merge_commit=false -F allow_squash_merge=true -F allow_rebase_merge=false \
+       >/dev/null 2>&1; then
+    echo "github-guard: $slug merge settings fixed ✓" >&2
+  else
+    echo "github-guard: PATCH failed for $slug (need repo admin?) — not blocking" >&2
+  fi
+fi
+exit 0

--- a/.githooks/pre-commit.d/github-protect-main.sh
+++ b/.githooks/pre-commit.d/github-protect-main.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# guard: github-protect-main
+# Ensure the repo's default branch is protected: require a PR (no direct
+# pushes), enforced for admins too, linear history, no force-push/deletion —
+# i.e. force everyone into PR mode. Owner-only, fail-open — NEVER blocks.
+set -u
+dir=$(cd "$(dirname "$0")/.." && pwd)
+# shellcheck source=../lib/common.sh
+. "$dir/lib/common.sh"
+
+slug=$(gg_repo_slug); [ -n "$slug" ] || exit 0
+gg_have_gh || { echo "github-guard: gh not installed/authed — skipping branch-protection check for $slug" >&2; exit 0; }
+owner=${slug%%/*}
+gg_user_owns "$owner" || exit 0
+
+branch=$(gh api "repos/$slug" --jq '.default_branch' 2>/dev/null) || {
+  echo "github-guard: couldn't read default branch for $slug — skipping" >&2; exit 0; }
+[ -n "$branch" ] || exit 0
+
+# Required status checks: auto-discover the checks that GATE A PULL REQUEST and
+# require them, strict. The only checks that can gate a PR are the ones that run
+# on `pull_request`, so discover them from recent pull_request workflow runs —
+# NOT from the default branch's HEAD commit. That commit also carries release
+# checks triggered by a tag push OR a `workflow_dispatch` on the branch; those
+# never run on a PR, and requiring them makes every PR wait forever on checks
+# that can't complete. Take the latest pull_request run per workflow and union
+# their check-run names: exactly the PR gate. The github-actions app filter
+# still excludes third-party checks like coderabbit. Self-healing — a renamed or
+# added CI job syncs after the next PR runs it AND it has passed on main once
+# (see the `passed` gate below); never strips existing checks on a transient
+# empty discovery. jq required; without it we preserve whatever's already set
+# (fail-open).
+#
+# Both `desired` (here) and `current` (the read-back below) end as compact JSON
+# straight from jq (`jq -c` / `tojson`), so escaping (quotes, backslashes) and
+# sort order match and the equality check below is exact.
+desired='[]'
+if command -v jq >/dev/null 2>&1; then
+  # check-suite of the latest pull_request run of each PR-triggering workflow.
+  # per_page=100 (not 50) widens the window so a workflow whose latest PR run is
+  # a bit older still gets discovered; the union below is the backstop for gaps.
+  suite_ids=$(gh api "repos/$slug/actions/runs?event=pull_request&per_page=100" \
+    --jq '[.workflow_runs[]?] | group_by(.workflow_id)[] | max_by(.created_at) | .check_suite_id' 2>/dev/null)
+  desired=$(
+    for sid in $suite_ids; do
+      gh api --paginate "repos/$slug/check-suites/$sid/check-runs?per_page=100" \
+        --jq '.check_runs[] | select(.app.slug=="github-actions") | .name' 2>/dev/null
+    done | jq -sRc 'split("\n") | map(select(length > 0)) | map({context: .}) | unique'
+  )
+  # Empty stdin yields "[]" here, but guard against a stray "null" too so a
+  # malformed value can never reach the protection PUT payload.
+  case "$desired" in '' | null) desired='[]' ;; esac
+fi
+
+# Checks that have ACTUALLY PASSED on the default branch — the gate for ADDING a
+# newly-discovered check to REQUIRED. A check discovered from PR runs is only
+# eligible to become required once it has concluded `success` on the default
+# branch's latest commit at least once; a check that has only ever been
+# pending/failure is NOT added. Without this gate the additive union below would
+# auto-require a brand-new or still-red check (e.g. a just-landed "E2E (full
+# topology)" that has never gone green on main), and because we also set
+# enforce_admins + strict that check would block EVERY merge — no one, not even
+# an admin, could merge until a check that has never passed somehow passes. We
+# never STRIP already-required checks (the union preserves `current`), so this
+# gates only the additive step. Query the default branch HEAD's check-runs and
+# keep the github-actions ones that concluded `success`. jq required; without it
+# `passed` stays '[]' so nothing new is added and `current` is preserved
+# (fail-open — never blocks). Empty/failed query behaves the same: add nothing.
+passed='[]'
+if command -v jq >/dev/null 2>&1; then
+  passed=$(gh api --paginate "repos/$slug/commits/$branch/check-runs?per_page=100" \
+    --jq '.check_runs[]? | select(.app.slug=="github-actions") | select(.conclusion=="success") | .name' 2>/dev/null \
+    | jq -sRc 'split("\n") | map(select(length > 0)) | unique')
+  case "$passed" in '' | null) passed='[]' ;; esac
+fi
+
+# ALL github-actions check-run NAMES on the default-branch HEAD (ANY conclusion)
+# — the evidence that lets the matrix-parent prune below fire ONLY on positive
+# proof a required context has vanished. Unlike `passed` (success-only, the
+# promotion gate) this keeps pending/failed runs too, because the prune's only
+# question is "does a check by this EXACT name still RUN on main at all". A real,
+# independent required check whose latest PR run merely fell outside the bounded
+# discovery window above still runs here, so it is never mistaken for a stale
+# matrix parent and stripped. jq required; empty on failure, and the prune treats
+# an empty list as "no evidence" and preserves the context (fail-open).
+head_names='[]'
+if command -v jq >/dev/null 2>&1; then
+  head_names=$(gh api --paginate "repos/$slug/commits/$branch/check-runs?per_page=100" \
+    --jq '.check_runs[]? | select(.app.slug=="github-actions") | .name' 2>/dev/null \
+    | jq -sRc 'split("\n") | map(select(length > 0)) | unique')
+  case "$head_names" in '' | null) head_names='[]' ;; esac
+fi
+
+# Current protection facts in one call: PR reviews present? admins enforced?
+# plus the currently-required checks from the modern `checks` field (normalized
+# to {context}, sorted). Each value is emitted on its OWN line, NOT through
+# `@tsv` — `@tsv` adds a second escaping pass on top of `tojson`, so a job name
+# containing `"` or `\` would read back double-escaped and never equal the
+# `jq -c`-encoded `desired`, re-applying protection on every commit. `tojson`
+# output is single-line, so line-reading each field is safe. Empty when unprotected.
+{ IFS= read -r has_reviews; IFS= read -r has_admins; IFS= read -r current; IFS= read -r review_count; } < <(
+  gh api "repos/$slug/branches/$branch/protection" --jq \
+    '(.required_pull_request_reviews != null),
+     (.enforce_admins.enabled // false),
+     ((.required_status_checks.checks // []) | map({context: .context}) | unique | tojson),
+     (.required_pull_request_reviews.required_approving_review_count // 0)' 2>/dev/null)
+[ -n "$current" ] || current='[]'
+# Preserve any already-configured approval count instead of hardcoding 0: re-applying
+# protection must never silently DOWNGRADE a team's "require N reviews" back to 0.
+# Default 0 (require a PR, no approvals) for the solo case / a fresh unprotected branch.
+# Sanitize to digits so only a number can reach the JSON payload below.
+case "$review_count" in '' | *[!0-9]*) review_count=0 ;; esac
+
+# An OPTIONAL committed declaration OVERRIDES discovery: `.githooks/required-checks`,
+# one check-run name per line (`#` comments and blank lines ignored; the single
+# word `none` means require no checks at all).
+#
+# Discovery below requires checks BY JOB NAME, which is only ever a guess at the
+# PR gate — and one class of guess is unfixable from the API alone. A workflow
+# whose `on: pull_request:` carries `paths:` filters reports NO check run for a PR
+# that touches nothing it watches; GitHub reads a required-but-absent check as
+# pending, so with enforce_admins nobody can merge and there is no failure to
+# point at. (A job skipped by a job-level `if:` is fine — it still reports, with
+# conclusion `skipped`, which SATISFIES protection. Only the workflow never
+# starting is fatal.) Telling those apart means parsing every workflow's YAML and
+# guessing at its filters, so instead a repo can just say what its gate is.
+#
+# The idiomatic answer is one always-run aggregate job that `needs:` the others,
+# named here — then jobs can be renamed, split into a matrix, made conditional or
+# path-filtered without ever stranding a merge. Declaring it is also the only way
+# to REMOVE a required check that discovery would otherwise keep re-adding, so
+# unlike discovery this path is allowed to strip.
+declared='[]'
+if [ -f "$dir/required-checks" ] && command -v jq >/dev/null 2>&1; then
+  declared=$(sed -e 's/#.*//' -e 's/[[:space:]]*$//' -e 's/^[[:space:]]*//' "$dir/required-checks" \
+    | jq -sRc 'split("\n") | map(select(length > 0)) | map({context: .}) | unique')
+  case "$declared" in '' | null) declared='[]' ;; esac
+  if [ "$declared" = '[]' ]; then
+    # Comments-only or empty: NOT read as "require nothing" — a file someone
+    # blanked mid-edit must not silently unprotect the branch. Fall through to
+    # discovery; `none` is the explicit way to ask for an empty set.
+    echo "github-guard: $dir/required-checks lists no checks — ignoring it (write 'none' to require none)" >&2
+  fi
+fi
+
+if [ "$declared" = '[{"context":"none"}]' ]; then
+  want='[]'
+elif [ "$declared" != '[]' ]; then
+  # Declared wins, exactly — except for a context that has NEITHER passed on the
+  # default branch NOR is already required. That is the typo gate: a misspelled
+  # name here would otherwise be required immediately, never report, and lock the
+  # repo with enforce_admins on (the same trap the `passed` promotion gate below
+  # exists to avoid). A declared check that is not eligible yet is skipped and
+  # self-heals as soon as it goes green on main once.
+  want=$(printf '%s\n%s\n%s' "$declared" "$passed" "$current" | jq -sc '
+    .[0] as $declared | .[1] as $passed | (.[2] | map(.context)) as $cur |
+    $declared | map(select(
+      (.context as $c | ($passed | index($c)) != null)
+      or (.context as $c | ($cur | index($c)) != null)
+    )) | unique')
+  skipped=$(printf '%s\n%s' "$declared" "$want" | jq -sc '(.[0] - .[1]) | map(.context)')
+  [ "$skipped" = '[]' ] || \
+    echo "github-guard: declared checks not required yet (never green on $branch): $skipped" >&2
+  if [ "$want" = '[]' ]; then
+    # Nothing declared is eligible — a typo, or an aggregate job that has not yet
+    # run green on main. Keep whatever is required today rather than stripping the
+    # gate down to nothing on the strength of a name that may not exist. It flips
+    # to the declared set on the first commit after that check passes on main.
+    echo "github-guard: no declared check is eligible yet — keeping current required checks" >&2
+    want="$current"
+  fi
+# Checks to require: be strictly ADDITIVE — union what's already required with the
+# newly-discovered checks THAT HAVE PASSED ON MAIN, never a bare replace. A
+# discovery that's non-empty but PARTIAL (a PR-gating workflow whose latest run
+# fell outside the window above) would otherwise overwrite `current` and silently
+# drop the missing workflows' checks — the exact "never strip existing checks"
+# promise, broken. The union keeps every already-required check (so nothing is
+# ever stripped) and adds a newly-seen check only when it appears in `passed`
+# (green on the default branch at least once) — a still-red / never-passed check
+# is discovered but NOT promoted to required, so it can't block merges. Empty
+# discovery → keep current untouched. (jq required for the union; without it we
+# already fell through with desired='[]' and keep current.) Reached only when the
+# repo has NOT declared its gate in .githooks/required-checks above.
+elif [ -n "$desired" ] && [ "$desired" != "[]" ]; then
+  # $desired is only ever non-'[]' when the jq-guarded discovery above populated
+  # it, so jq is guaranteed here — union existing (`current`, always kept) with
+  # the subset of discovered checks that are also in `passed`. `current` is added
+  # unconditionally so this never strips; discovered checks are gated on `passed`
+  # so a never-green check is never newly required.
+  want=$(printf '%s\n%s\n%s' "$current" "$desired" "$passed" \
+    | jq -sc '
+        .[0] as $current | .[1] as $desired | .[2] as $passed |
+        ( $current
+          + ( $desired | map(select(.context as $c | ($passed | index($c)) != null)) )
+        )
+        | map(select(.context? != null)) | unique')
+  # Heal a stale matrix-PARENT context. When a CI job is refactored from a single
+  # job (check run "Build") into a matrix (runs "Build (cmd/api)", "Build (…)"),
+  # the bare "Build" is NEVER reported as a check run again — but the additive
+  # union above keeps requiring it, so every PR blocks forever on a check that
+  # can't complete (enforce_admins means not even an admin merge escapes). Prune a
+  # required context C ONLY with POSITIVE evidence it has vanished: discovery
+  # shows a matrix child "C (…)", AND bare C is confirmed ABSENT from the default
+  # branch HEAD's own check-runs ($head_names). Name-prefix alone is too weak —
+  # discovery is bounded to recent PR runs, so an independent required "C" can be
+  # absent from discovery while an UNRELATED "C (…)" is present; keying off that
+  # would strip a still-valid gate. Requiring C to also be missing from the fresh
+  # HEAD check-run set rules that out: a real, active C still runs on main and
+  # stays in $head_names, so only a genuinely refactored-away parent is pruned. No
+  # HEAD evidence (empty $head_names) → preserve (fail-open, never strip).
+  want=$(printf '%s\n%s\n%s' "$want" "$desired" "$head_names" | jq -sc '
+    .[0] as $want | (.[1] | map(.context)) as $dctx | .[2] as $head |
+    $want | map(
+      (.context) as $c |
+      select(
+        ($dctx | index($c)) != null                       # itself a discovered check → keep
+        or (($dctx | any(startswith($c + " ("))) | not)   # no matrix child shadows it → keep
+        or (($head | length) == 0)                        # no HEAD evidence → keep (fail-open)
+        or (($head | index($c)) != null)                  # still runs on main HEAD → keep (not stale)
+      )
+    )')
+elif [ -n "$current" ] && [ "$current" != "[]" ]; then
+  want="$current"
+else
+  want="[]"
+fi
+
+# Already exactly how we want it (PR-mode + admins + matching checks)? Skip.
+if [ "$has_reviews" = "true" ] && [ "$has_admins" = "true" ] && [ "${current:-[]}" = "$want" ]; then
+  exit 0
+fi
+
+if [ "$want" = "[]" ]; then
+  rsc='null'
+  echo "github-guard: protecting $slug:$branch (require PR, enforce admins, linear history)…" >&2
+else
+  rsc="{ \"strict\": true, \"checks\": $want }"
+  echo "github-guard: protecting $slug:$branch (require PR, enforce admins, linear history, required checks $want)…" >&2
+fi
+
+payload=$(cat <<JSON
+{
+  "required_status_checks": $rsc,
+  "enforce_admins": true,
+  "required_pull_request_reviews": { "required_approving_review_count": $review_count, "dismiss_stale_reviews": false, "require_code_owner_reviews": false },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+JSON
+)
+if printf '%s' "$payload" | gh api -X PUT "repos/$slug/branches/$branch/protection" \
+     -H "Accept: application/vnd.github+json" --input - >/dev/null 2>&1; then
+  echo "github-guard: $slug:$branch protected ✓" >&2
+else
+  echo "github-guard: protection PUT failed for $slug:$branch (need repo admin?) — not blocking" >&2
+fi
+exit 0

--- a/.githooks/pre-commit.d/rust-clippy.sh
+++ b/.githooks/pre-commit.d/rust-clippy.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# guard: rust-clippy
+# Block the commit if `cargo clippy` reports any warning. Only runs in a Cargo
+# project (skips silently otherwise). BLOCKS (exit 1) on lint failures — clippy
+# flags logic smells, not layout, so a human should look rather than have it
+# auto-rewritten.
+set -u
+dir=$(cd "$(dirname "$0")/.." && pwd)   # .githooks/
+# shellcheck source=../lib/common.sh
+. "$dir/lib/common.sh"
+
+gg_is_rust || exit 0
+root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# Fresh-clone safety: clippy must compile, which needs every `path = "…"`
+# dependency present on disk. A crate whose path-dep sibling (e.g. ../foo) isn't
+# checked out yet can't be linted — running clippy anyway would hard-block the
+# commit on a missing sibling, not a real lint. Skip in that case (CI, which has
+# every sibling, is the backstop). Scans all tracked Cargo.toml files; a path
+# resolves against the manifest's own directory.
+while IFS= read -r toml; do
+  [ -f "$root/$toml" ] || continue
+  tdir=$(cd "$(dirname "$root/$toml")" && pwd) || continue
+  # Feed the loop each `path = "…"` value from this manifest. Anchor `path` to a
+  # key boundary (start / space / , / {) so `manifest-path` & friends don't match,
+  # and drop full-line comments first.
+  while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    if [ ! -e "$tdir/$rel" ]; then
+      echo "github-guard: rust-clippy skipped — path dependency '$rel' (in $toml) isn't" >&2
+      echo "             checked out; clippy can't compile without it. CI enforces clippy." >&2
+      exit 0
+    fi
+  done < <(grep -vE '^[[:space:]]*#' "$root/$toml" 2>/dev/null \
+             | grep -oE '(^|[[:space:],{])path[[:space:]]*=[[:space:]]*"[^"]+"' | sed -E 's/.*"([^"]+)".*/\1/')
+done < <(git -C "$root" ls-files '*Cargo.toml' 'Cargo.toml')
+
+# Run via gg_cargo (the rustup shim), which honors rust-toolchain.toml so local
+# clippy == CI clippy. rc=2 means no cargo at all → skip rather than block.
+rc=0; ( cd "$root" && gg_cargo clippy --all-targets -- -D warnings ); rc=$?
+if [ "$rc" = 2 ]; then exit 0; fi
+if [ "$rc" != 0 ]; then
+  echo "github-guard: clippy found issues above — fix them, or bypass once with: git commit --no-verify" >&2
+  exit 1
+fi
+exit 0

--- a/.githooks/pre-commit.d/rust-deps-pinned.sh
+++ b/.githooks/pre-commit.d/rust-deps-pinned.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# guard: rust-deps-pinned
+# Reproducible-release gate for Cargo projects: refuse a commit that would make
+# a versioned tag non-reproducible. Only runs when Cargo.toml is present (skips
+# silently otherwise), so non-Rust repos are unaffected. BLOCKS on a real
+# problem; fail-OPEN whenever the environment can't give a reliable answer (no
+# cargo, empty offline cache, a path-dep sibling not checked out) — CI's
+# `cargo … --locked` is the authoritative backstop.
+#
+# It catches the ways a "pinned" release silently isn't:
+#   1. A workflow that FLOATING-clones a sibling repo (same GitHub owner) with
+#      no `--branch`/`-b` — the published build then resolves against whatever
+#      that repo's HEAD happens to be, not a fixed tag.
+#   2. A workflow `actions/checkout` of a sibling repo with no `ref:` — same
+#      floating hazard, via the action instead of raw git.
+#   3. A committed Cargo.lock whose own package version drifted from Cargo.toml
+#      (bumped the manifest, forgot to re-lock — only blows up at `cargo publish`).
+#   4. A Cargo.lock that `cargo metadata --locked` reports as stale.
+#
+# Bypass once (NOT recommended): git commit --no-verify
+set -u
+dir=$(cd "$(dirname "$0")/.." && pwd)   # .githooks/
+# shellcheck source=../lib/common.sh
+. "$dir/lib/common.sh"
+
+gg_is_rust || exit 0
+root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$root" || exit 0
+fail=0
+
+# ── 1 & 2. no FLOATING fetch of a sibling repo (same owner) in any workflow ──
+# A "sibling" is another repo under the same GitHub owner as origin — those are
+# the path/git dependency crates a release must pin. If the owner can't be
+# determined (no github origin) we skip these two checks; the lock checks below
+# still run.
+owner=$(gg_repo_slug); owner=${owner%%/*}
+if [ -n "$owner" ] && [ -d .github/workflows ]; then
+  shopt -s nullglob 2>/dev/null || true
+  for wf in .github/workflows/*.yml .github/workflows/*.yaml; do
+    [ -f "$wf" ] || continue
+    # Join shell line-continuations (a trailing '\') into one logical line before
+    # scanning: in a `run: |` block a `git clone …\` and its `--branch vX` land on
+    # two physical lines, and a per-physical-line check would flag the first as
+    # unpinned even though the clone is pinned.
+    logical=""
+    while IFS= read -r line || [ -n "$line" ]; do
+      line=${line%$'\r'}
+      logical="${logical:+$logical }$line"
+      case "$logical" in *\\) logical=${logical%\\}; continue ;; esac   # keep joining
+      case "$logical" in
+        *"git clone"*github.com[:/]"$owner"/*)
+          # A real pin is an IMMUTABLE ref. Pull out the --branch/-b value: empty
+          # means no pin at all, and a well-known MUTABLE branch name (main/master/
+          # …) is just as floating as none — block both; anything else (a tag) ok.
+          brval=$(printf '%s' "$logical" | sed -nE 's/.*(^|[[:space:]])(--branch[ =]|-b[[:space:]]*)([^[:space:]]+).*/\3/p')
+          brval=${brval//\"/}; brval=${brval//\'/}     # strip surrounding quotes
+          # Heuristic blocklist of well-known mutable branch names (not exhaustive
+          # by design — the authoritative reproducibility gate is the Cargo.lock
+          # checks below + CI's --locked; this just catches the common offenders).
+          # Matched case-insensitively so Main/MAIN/Develop are caught too.
+          case "$(printf '%s' "$brval" | tr '[:upper:]' '[:lower:]')" in
+            main | master | develop | dev | trunk | head | next | staging | release | canary)
+              echo "[deps] FLOATING git clone — --branch '$brval' is a MUTABLE branch (pin a tag) in $wf:" >&2
+              echo "       ${logical#"${logical%%[![:space:]]*}"}" >&2
+              fail=1 ;;
+            '')
+              echo "[deps] FLOATING git clone of a sibling repo (add --branch v<X>) in $wf:" >&2
+              echo "       ${logical#"${logical%%[![:space:]]*}"}" >&2
+              fail=1 ;;
+            *) : ;;                                        # pinned to a tag → ok
+          esac ;;
+      esac
+      logical=""
+    done < "$wf"
+  done
+
+  # actions/checkout of an explicit sibling repository: with no ref:. Parsed
+  # with ruby's stdlib YAML when available; skipped (never failed) if ruby isn't.
+  if command -v ruby >/dev/null 2>&1; then
+    ruby -ryaml -e '
+      # aliases: is a ruby >= 2.7 kwarg; on older rubies (e.g. macOS system ruby)
+      # passing it raises ArgumentError, which — if rescued straight to nil — would
+      # silently skip EVERY workflow and disable this check. Fall back to a plain
+      # safe_load there so the ref-pinning check still runs.
+      def load_wf(f)
+        YAML.safe_load(File.read(f), aliases: true)
+      rescue ArgumentError
+        (YAML.safe_load(File.read(f)) rescue nil)
+      rescue
+        nil
+      end
+      owner = ARGV[0]
+      bad = []
+      Dir.glob(".github/workflows/*.{yml,yaml}").each do |wf|
+        doc = load_wf(wf)
+        next unless doc.is_a?(Hash)
+        (doc["jobs"] || {}).each_value do |job|
+          next unless job.is_a?(Hash)
+          (job["steps"] || []).each do |st|
+            next unless st.is_a?(Hash)
+            next unless st["uses"].to_s.start_with?("actions/checkout")
+            w = st["with"] || {}
+            repo = w["repository"].to_s
+            next if repo.empty?
+            next unless repo.split("/").first == owner        # sibling only
+            bad << "#{wf}: actions/checkout #{repo} has no ref: (pin to a tag)" if w["ref"].to_s.empty?
+          end
+        end
+      end
+      unless bad.empty?
+        STDERR.puts "[deps] FLOATING actions/checkout of a sibling repo (add ref: v<X>):"
+        bad.each { |b| STDERR.puts "       #{b}" }
+        exit 1
+      end
+    ' "$owner" || fail=1
+  fi
+fi
+
+# ── 3. Cargo.lock consistency — only when the repo actually commits a lock ───
+# Respect the repo's own convention: enforce the lock if it's tracked; never
+# invent one for a library that deliberately gitignores it.
+lock_tracked=0; git ls-files --error-unmatch Cargo.lock >/dev/null 2>&1 && lock_tracked=1
+if [ "$lock_tracked" = 1 ] && [ ! -f Cargo.lock ]; then
+  echo "[deps] Cargo.lock is tracked but missing from the working tree." >&2
+  echo "       Restore it: git checkout -- Cargo.lock   (or: cargo generate-lockfile)" >&2
+  fail=1
+elif [ -f Cargo.lock ]; then
+  # Read name/version ONLY from the [package] section. A workspace root, or a
+  # manifest carrying [[bin]]/[lib]/[workspace.dependencies] sections, has other
+  # `name =`/`version =` keys; a first-match scan would grab the wrong one (or, in
+  # a virtual workspace root with no [package], nothing meaningful) and either
+  # mis-compare or silently no-op. Section-scoping keeps the drift check honest;
+  # a manifest with no [package] (virtual workspace root) correctly yields empty
+  # and the guarded block below skips.
+  pkg=$(awk -F'"' '
+    /^[[:space:]]*\[/ { inpkg = ($0 ~ /^[[:space:]]*\[package\]/) }
+    inpkg && /^[[:space:]]*name[[:space:]]*=/ { print $2; exit }
+  ' Cargo.toml)
+  ver=$(awk -F'"' '
+    /^[[:space:]]*\[/ { inpkg = ($0 ~ /^[[:space:]]*\[package\]/) }
+    inpkg && /^[[:space:]]*version[[:space:]]*=/ { print $2; exit }
+  ' Cargo.toml)
+  if [ -n "$pkg" ] && [ -n "$ver" ]; then
+    lockver=$(awk -v p="$pkg" '
+      $0 == "name = \"" p "\"" { hit=1; next }
+      hit && /^version = / { gsub(/^version = "|"$/, "", $0); print; exit }
+    ' Cargo.lock)
+    if [ -n "$lockver" ] && [ "$lockver" != "$ver" ]; then
+      echo "[deps] Cargo.lock records $pkg = $lockver but Cargo.toml is $ver — the lock" >&2
+      echo "       drifted from the manifest. Run: cargo generate-lockfile && git add Cargo.lock" >&2
+      fail=1
+    fi
+  fi
+
+  # ── 4. authoritative stale-lock check (cargo is the oracle), best-effort ──
+  # `cargo metadata --locked` refuses to rewrite the lock and errors if it's out
+  # of date. Run --offline so the hook stays fast and never touches the network.
+  #
+  # BUT only when the graph resolves the same as CI's. A crate with an EXTERNAL
+  # `path = "../sibling"` dependency can't guarantee that locally: a sibling
+  # checked out at a version that differs from what the lock records (routine in
+  # multi-repo dev) makes cargo want to re-lock, which surfaces as the exact same
+  # "cannot update the lock file" error as true staleness — a false block we must
+  # not raise. So skip part 4 whenever an external path dep is present; CI (with
+  # siblings pinned to their tagged versions) is the authoritative --locked
+  # backstop, and parts 1–3 above still apply. Registry-only / in-repo-workspace
+  # crates keep the full check.
+  ext_path_dep=0
+  while IFS= read -r toml; do
+    # Anchor `path` to a key boundary (start / space / , / {) so it matches the
+    # dependency `path =` key, not a suffix like `manifest-path =`; drop full-line
+    # comments so a commented example doesn't count.
+    if grep -vE '^[[:space:]]*#' "$toml" 2>/dev/null \
+         | grep -qE '(^|[[:space:],{])path[[:space:]]*=[[:space:]]*"\.\.?/'; then ext_path_dep=1; break; fi
+  done < <(git ls-files '*Cargo.toml' 'Cargo.toml')
+  if [ "$ext_path_dep" = 0 ]; then
+    # BLOCK only on the staleness signal; any other failure (empty offline cache,
+    # etc.) is an environment limitation → skip. gg_cargo returns 2 with no cargo.
+    if err=$(gg_cargo metadata --locked --offline --format-version 1 2>&1 >/dev/null); then
+      : # lock is fresh
+    else
+      rc=$?
+      if [ "$rc" != 2 ] && printf '%s\n' "$err" | grep -qiE 'cannot update the lock file|needs to be updated|out.?of.?date'; then
+        echo "[deps] Cargo.lock is STALE — it no longer matches Cargo.toml:" >&2
+        printf '%s\n' "$err" | grep -iE 'cannot update the lock file|needs to be updated|out.?of.?date' | head -1 | sed 's/^/       /' >&2
+        echo "       Fix: cargo generate-lockfile && git add Cargo.lock" >&2
+        fail=1
+      fi
+    fi
+  fi
+fi
+
+if [ "$fail" != 0 ]; then
+  echo "github-guard: rust-deps-pinned blocked the commit — pin your dependencies (above)." >&2
+  echo "             Bypass once (NOT recommended): git commit --no-verify" >&2
+  exit 1
+fi
+exit 0

--- a/.githooks/pre-commit.d/rust-fmt.sh
+++ b/.githooks/pre-commit.d/rust-fmt.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# guard: rust-fmt
+# Auto-format staged Rust code with `cargo fmt` and re-stage it, so the commit
+# goes in formatted. Only runs in a Cargo project (skips silently otherwise).
+# NEVER blocks — it just fixes layout, so there's nothing to argue about.
+#
+# Safety (the important bit): `cargo fmt` rewrites a file's FULL on-disk
+# content, so blindly `git add`-ing a formatted file would also stage any
+# UNSTAGED edits sitting in that same file — silently sweeping a developer's
+# work-in-progress into the commit. So we only re-stage files that were
+# *fully* staged (no unstaged changes). A partially-staged file is left as-is
+# (its staged snapshot commits unformatted) with a notice — never a silent
+# sweep.
+set -u
+dir=$(cd "$(dirname "$0")/.." && pwd)   # .githooks/
+# shellcheck source=../lib/common.sh
+. "$dir/lib/common.sh"
+
+gg_is_rust || exit 0
+root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# Staged .rs files, and (captured BEFORE formatting) which .rs files also carry
+# unstaged changes — their intersection is the "partially staged" danger set.
+staged=$(git diff --cached --name-only --diff-filter=ACM -- '*.rs')
+[ -n "$staged" ] || exit 0
+unstaged=$(git diff --name-only --diff-filter=ACMD -- '*.rs')
+
+# Format via gg_cargo (the rustup shim), which honors rust-toolchain.toml so it
+# matches CI. If cargo isn't available, don't block — just skip.
+( cd "$root" && gg_cargo fmt ) || { echo "github-guard: 'cargo fmt' skipped/failed — not blocking" >&2; exit 0; }
+
+printf '%s\n' "$staged" | while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  if printf '%s\n' "$unstaged" | grep -qxF -- "$f"; then
+    echo "github-guard: rust-fmt left '$f' unformatted in this commit — it has unstaged" >&2
+    echo "             changes, and re-staging after format would mix them in. Stage it" >&2
+    echo "             fully (git add '$f'), or run 'cargo fmt' + 'git add' yourself." >&2
+    continue
+  fi
+  [ -f "$root/$f" ] && git add -- "$root/$f" 2>/dev/null || true
+done
+exit 0

--- a/.githooks/pre-merge-commit
+++ b/.githooks/pre-merge-commit
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# github-guard hook: pre-merge-commit
+#
+# Fires:    Before a merge commit is created (a non-fast-forward `git merge`/`git pull`).
+# Use for:  Refusing merge commits or running extra merge checks.
+# Blocking: yes (non-zero aborts the merge commit)
+#
+# Dispatcher: runs every executable script in  .githooks/pre-merge-commit.d/  in lexical
+# order. Add behaviour by dropping a guard script there; remove it by deleting
+# the file (or `chmod -x`). No pre-merge-commit.d/ (or an empty one) = no-op. Managed by
+# github-guard — edit guards in the .d/ dir, not this file.
+d=$(cd "$(dirname "$0")" && pwd)
+exec "$d/lib/run-guards.sh" "$(basename "$0")" "$@"

--- a/.githooks/pre-merge-commit.d/git-block-merge-commit.sh
+++ b/.githooks/pre-merge-commit.d/git-block-merge-commit.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# guard: git-block-merge-commit
+# Refuse to CREATE a merge commit locally, keeping history linear. This fires
+# on a non-fast-forward `git merge` / `git pull`. Purely local, no network.
+# Hard block (exit 1). Bypass only with git's built-in --no-verify.
+printf 'github-guard: BLOCKED — this merge would create a merge commit.\n' >&2
+printf '  Linearize instead:  git merge --ff-only   |   git pull --rebase   |   git rebase\n' >&2
+exit 1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# github-guard hook: pre-push
+#
+# Fires:    Before `git push` transfers objects. The refs being pushed arrive on stdin.
+# Use for:  Blocking bad pushes — merge commits, WIP commits, failing tests.
+# Blocking: yes (non-zero aborts the push)
+#
+# Dispatcher: runs every executable script in  .githooks/pre-push.d/  in lexical
+# order. Add behaviour by dropping a guard script there; remove it by deleting
+# the file (or `chmod -x`). No pre-push.d/ (or an empty one) = no-op. Managed by
+# github-guard — edit guards in the .d/ dir, not this file.
+d=$(cd "$(dirname "$0")" && pwd)
+exec "$d/lib/run-guards.sh" "$(basename "$0")" "$@"

--- a/.githooks/pre-push.d/git-block-merge-commits.sh
+++ b/.githooks/pre-push.d/git-block-merge-commits.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# guard: git-block-merge-commits
+# Block any push whose pushed range contains a merge commit — the safety net
+# behind git-block-merge-commit (also catches merges that arrived via fetch,
+# cherry-pick, or a merge-preserving rebase). Reads the ref list git provides
+# on stdin. Purely local. Hard block. Bypass only with --no-verify.
+set -u
+status=0
+while read -r local_ref local_sha remote_ref remote_sha; do
+  # Deleting a remote branch (local_sha all-zero): nothing to inspect.
+  printf '%s' "$local_sha" | grep -qE '^0+$' && continue
+  if printf '%s' "$remote_sha" | grep -qE '^0+$'; then
+    # New branch on the remote: inspect commits not already on any remote ref.
+    merges=$(git rev-list --merges "$local_sha" --not --remotes 2>/dev/null)
+  else
+    merges=$(git rev-list --merges "${remote_sha}..${local_sha}" 2>/dev/null)
+  fi
+  if [ -n "$merges" ]; then
+    printf 'github-guard: BLOCKED — push to %s contains merge commit(s):\n' "$remote_ref" >&2
+    printf '%s\n' "$merges" | sed 's/^/  /' >&2
+    printf '  Linearize first:  git pull --rebase   |   git rebase <upstream>\n' >&2
+    status=1
+  fi
+done
+exit $status

--- a/.githooks/pre-push.d/git-changelog.sh
+++ b/.githooks/pre-push.d/git-changelog.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# guard: git-changelog (pre-push)
+# When you push a version tag (refs/tags/vN.N.N…), require the release to be
+# documented. If the repo keeps a changelog — a root CHANGELOG.md and/or a
+# "Changelog" section in README.md — then for the tag being pushed:
+#   1. CHANGELOG.md must have a section for that version (if CHANGELOG.md exists),
+#   2. the README changelog section must have one too (if that section exists),
+#   3. the README changelog must list <= 10 versions (older live in CHANGELOG.md),
+#   4. the README changelog must link to CHANGELOG.md.
+# It reads the *tagged commit's* files, so it checks what actually ships. Blocks
+# the push on violation. Self-gates: no version tag, or no changelog anywhere = no-op.
+#
+# Conventions: the README changelog section is a heading matching
+# changelog/release notes/recent changes/releases/history; version entries
+# inside it are deeper (e.g. `### v0.2.0`) sub-headings. Bypass: git push --no-verify.
+#
+# Also usable as a CLI: `git-changelog.sh notes vX.Y.Z` prints that version's
+# release notes from CHANGELOG.md. A release pipeline can call this, so the
+# changelog this guard enforces is the single source of truth for release bodies.
+set -u
+dir=$(cd "$(dirname "$0")/.." && pwd)   # .githooks/
+# shellcheck source=../lib/common.sh
+. "$dir/lib/common.sh"
+
+# --- changelog extraction (shared by the hook below and a release pipeline) ---
+# Print CHANGELOG.md's body for a version (no heading) — from its "## vX.Y.Z"
+# heading up to the next "## v" heading, with leading blank lines trimmed.
+# Reads the changelog on stdin.
+changelog_section() {  # $1 = version, no leading v
+  awk -v ver="$1" '
+    /^##[[:space:]]+v/ {
+      s=$0; sub(/^##[[:space:]]+v/, "", s); split(s, a, /[[:space:]]/); v=a[1]
+      if (insec) exit
+      if (v == ver) { insec=1; next }
+    }
+    insec {
+      if (!started && $0 ~ /^[[:space:]]*$/) next
+      started=1; print
+    }
+  '
+}
+
+# Print the version of the next-older release (the "## v" heading after $1),
+# for the "Full Changelog" compare link. Empty for the first release.
+changelog_prev_version() {  # $1 = version, no leading v
+  awk -v ver="$1" '
+    /^##[[:space:]]+v/ {
+      s=$0; sub(/^##[[:space:]]+v/, "", s); split(s, a, /[[:space:]]/); v=a[1]
+      if (found) { print v; exit }
+      if (v == ver) found=1
+    }
+  '
+}
+
+# Subcommand `notes <version>`: emit GitHub release notes for a version from the
+# SAME CHANGELOG.md this guard enforces, so the release body can't drift from the
+# changelog. Fails loudly if the section is missing (the guard would have blocked
+# the tag anyway).  Usage: git-changelog.sh notes v0.4.0
+if [ "${1:-}" = "notes" ]; then
+  ver=${2#v}
+  root=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "git-changelog: not a git repo" >&2; exit 1; }
+  cl="$root/CHANGELOG.md"
+  [ -f "$cl" ] || { echo "git-changelog: no CHANGELOG.md" >&2; exit 1; }
+  body=$(changelog_section "$ver" < "$cl")
+  [ -n "$body" ] || { echo "git-changelog: no '## v$ver' section in CHANGELOG.md" >&2; exit 1; }
+  printf "## What's Changed\n\n%s\n" "$body"
+  prev=$(changelog_prev_version "$ver" < "$cl")
+  slug=$(gg_repo_slug)
+  if [ -n "$prev" ] && [ -n "$slug" ]; then
+    printf '\n**Full Changelog**: https://github.com/%s/compare/v%s...v%s\n' "$slug" "$prev" "$ver"
+  fi
+  exit 0
+fi
+
+# Self-gate: repos without a changelog convention are unaffected.
+gg_has_changelog || exit 0
+
+# Extract the README "changelog" section: everything after its heading up to the
+# next level-2 (`## `) heading. (Version entries inside are `### …`, which don't
+# end it.)
+readme_changelog_section() {
+  awk '
+    /^## / {
+      low = tolower($0)
+      if (low ~ /change ?log|release notes|recent changes|releases|history/) { insec=1; next }
+      else if (insec) { insec=0 }
+    }
+    insec { print }
+  '
+}
+
+# True if any heading line in stdin names this version (tag or bare version,
+# with digit boundaries so 0.2.0 doesn't match 10.2.0).
+heading_has_version() {  # $1 = tag, $2 = ver-regex (dots escaped)
+  grep -qE "^#{1,6}[[:space:]].*((^|[^0-9.])$2([^0-9]|\$)|$1)"
+}
+
+status=0
+while read -r local_ref local_sha _remote_ref _remote_sha; do
+  case "$local_ref" in refs/tags/v[0-9]*) ;; *) continue ;; esac     # version tags only
+  printf '%s' "$local_sha" | grep -qE '^0+$' && continue              # tag deletion
+
+  tag=${local_ref#refs/tags/}
+  ver=${tag#v}
+  ver_re=$(printf '%s' "$ver" | sed 's/\./\\./g')
+
+  changelog=$(git show "$local_sha:CHANGELOG.md" 2>/dev/null || true)
+  readme=$(git show "$local_sha:README.md" 2>/dev/null || true)
+  readme_cl=$(printf '%s\n' "$readme" | readme_changelog_section)
+
+  have_cl=0; [ -n "$changelog" ] && have_cl=1
+  have_rcl=0; [ -n "$readme_cl" ] && have_rcl=1
+  [ "$have_cl" = 1 ] || [ "$have_rcl" = 1 ] || continue               # no changelog convention → skip
+
+  if [ "$have_cl" = 1 ] && ! printf '%s\n' "$changelog" | heading_has_version "$tag" "$ver_re"; then
+    echo "git-changelog: CHANGELOG.md has no section for $tag." >&2; status=1
+  fi
+  if [ "$have_rcl" = 1 ]; then
+    if ! printf '%s\n' "$readme_cl" | heading_has_version "$tag" "$ver_re"; then
+      echo "git-changelog: README changelog has no section for $tag." >&2; status=1
+    fi
+    n=$(printf '%s\n' "$readme_cl" | grep -cE '^#{1,6}[[:space:]].*[0-9]+\.[0-9]+' || true)
+    if [ "$n" -gt 10 ]; then
+      echo "git-changelog: README changelog lists $n versions (max 10) — trim the oldest; full history stays in CHANGELOG.md." >&2; status=1
+    fi
+    if [ "$have_cl" = 1 ] && ! printf '%s\n' "$readme_cl" | grep -qi 'CHANGELOG\.md'; then
+      echo "git-changelog: README changelog must link to CHANGELOG.md." >&2; status=1
+    fi
+  fi
+done
+
+if [ "$status" != 0 ]; then
+  echo "  document the release then re-tag, or bypass once: git push --no-verify" >&2
+fi
+exit "$status"

--- a/.githooks/pre-push.d/git-tags-on-main.sh
+++ b/.githooks/pre-push.d/git-tags-on-main.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# guard: git-tags-on-main
+# Block pushing any tag whose target commit is not contained in the default
+# branch (main). Release tags must mark a commit that actually landed on main,
+# never one stranded on a feature branch or a pre-squash line. Reads the ref
+# list git provides on stdin. Purely local. Hard block. Bypass with --no-verify.
+#
+# Git has no hook for `git tag` creation (only reference-transaction, which we
+# don't manage), so the push is the enforcement point — a tag only matters once
+# it is shared. Annotated tags are peeled to their commit before the check.
+set -u
+
+# The remote being pushed to is the hook's first arg; resolve the default
+# branch against THAT remote rather than a hardcoded "origin", so pushing a
+# tag to an alternate remote still validates against the right branch.
+remote="${1:-origin}"
+
+# Resolve the default branch ($remote/HEAD -> main fallback) and collect every
+# tip that represents it: the remote-tracking ref and the local branch. A tag
+# commit reachable from EITHER counts as on-main, so a momentarily-stale
+# remote-tracking ref can't cause a false block.
+default=$(git symbolic-ref --quiet --short "refs/remotes/$remote/HEAD" 2>/dev/null)
+default=${default#"$remote"/}
+[ -n "$default" ] || default=main
+
+mains=""
+for ref in "refs/remotes/$remote/$default" "refs/heads/$default"; do
+  sha=$(git rev-parse --quiet --verify "$ref" 2>/dev/null) && mains="$mains $sha"
+done
+# Can't locate main at all (no clone of it locally) — fail open, never block.
+[ -n "$mains" ] || {
+  echo "github-guard: can't resolve '$default' locally — skipping tag-on-main check" >&2
+  exit 0
+}
+
+status=0
+while read -r local_ref local_sha remote_ref remote_sha; do
+  case "$local_ref" in refs/tags/*) ;; *) continue ;; esac
+  # Tag deletion (local_sha all-zero): nothing to inspect.
+  printf '%s' "$local_sha" | grep -qE '^0+$' && continue
+
+  # Peel annotated/lightweight tag to the commit it ultimately points at. A tag
+  # that doesn't peel to a commit (points at a tree/blob) can never be on the
+  # default branch — block it rather than silently letting it through.
+  commit=$(git rev-parse --quiet --verify "${local_sha}^{commit}" 2>/dev/null) || {
+    tag=${remote_ref#refs/tags/}
+    printf 'github-guard: BLOCKED — tag %s does not point at a commit object.\n' "$tag" >&2
+    status=1
+    continue
+  }
+
+  on_main=0
+  for m in $mains; do
+    if git merge-base --is-ancestor "$commit" "$m" 2>/dev/null; then on_main=1; break; fi
+  done
+
+  if [ "$on_main" != 1 ]; then
+    tag=${remote_ref#refs/tags/}
+    printf 'github-guard: BLOCKED — tag %s points at %s, which is not on %s.\n' \
+      "$tag" "$(git rev-parse --short "$commit")" "$default" >&2
+    printf '  Release tags must mark a commit that landed on %s. Re-point it:\n' "$default" >&2
+    printf "    git tag -f '%s' <commit-on-%s>   # e.g. the squash-merge commit\n" "$tag" "$default" >&2
+    printf "    git push --force '%s' '%s'\n" "$remote" "$tag" >&2
+    status=1
+  fi
+done
+exit $status

--- a/.githooks/pre-rebase
+++ b/.githooks/pre-rebase
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# github-guard hook: pre-rebase
+#
+# Fires:    Before `git rebase` starts.
+# Use for:  Forbidding rebases of already-published branches.
+# Blocking: yes (non-zero stops the rebase)
+#
+# Dispatcher: runs every executable script in  .githooks/pre-rebase.d/  in lexical
+# order. Add behaviour by dropping a guard script there; remove it by deleting
+# the file (or `chmod -x`). No pre-rebase.d/ (or an empty one) = no-op. Managed by
+# github-guard — edit guards in the .d/ dir, not this file.
+d=$(cd "$(dirname "$0")" && pwd)
+exec "$d/lib/run-guards.sh" "$(basename "$0")" "$@"

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# github-guard hook: prepare-commit-msg
+#
+# Fires:    After the default commit message is prepared, before the editor opens.
+# Use for:  Injecting templates, ticket IDs, or trailers into the message.
+# Blocking: yes (non-zero aborts) — but mainly edits the message file
+#
+# Dispatcher: runs every executable script in  .githooks/prepare-commit-msg.d/  in lexical
+# order. Add behaviour by dropping a guard script there; remove it by deleting
+# the file (or `chmod -x`). No prepare-commit-msg.d/ (or an empty one) = no-op. Managed by
+# github-guard — edit guards in the .d/ dir, not this file.
+d=$(cd "$(dirname "$0")" && pwd)
+exec "$d/lib/run-guards.sh" "$(basename "$0")" "$@"

--- a/.githooks/sendemail-validate
+++ b/.githooks/sendemail-validate
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# github-guard hook: sendemail-validate
+#
+# Fires:    In `git send-email`, to validate a patch before it is sent.
+# Use for:  Checking outgoing patches before they leave.
+# Blocking: yes (non-zero stops the send)
+#
+# Dispatcher: runs every executable script in  .githooks/sendemail-validate.d/  in lexical
+# order. Add behaviour by dropping a guard script there; remove it by deleting
+# the file (or `chmod -x`). No sendemail-validate.d/ (or an empty one) = no-op. Managed by
+# github-guard — edit guards in the .d/ dir, not this file.
+d=$(cd "$(dirname "$0")" && pwd)
+exec "$d/lib/run-guards.sh" "$(basename "$0")" "$@"


### PR DESCRIPTION
Client-side git hooks, committed so they travel with the repository. Installed from the `github-guard` skill, the same set the other repositories here carry.

Each guard self-gates, so nothing fires where it does not apply: the `rust-*` guards do nothing without a `Cargo.toml`, and the `github-*` guards do nothing on a remote the account does not own.

**Blocks:** merge commits (locally and on push, since this repository squash-merges), committing keys/certificates/env files/merge cruft, trailing whitespace, and non-LFS files over 10 MiB.

**Reconciles on GitHub:** squash-only merges, and a protected default branch requiring a pull request with its checks. That already happened when this commit was made — the guards act at commit time, so the settings are live now regardless of when this merges.

**One manual step per clone:** `git config core.hooksPath .githooks`. That setting is per-clone and cannot be committed.