### PR TITLE
Tidy the version output, and stop source builds unpinning a release

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
+	"time"
 
 	"github.com/christhomas/docker-dev-tools/internal/config"
 	"github.com/christhomas/docker-dev-tools/internal/docker"
@@ -18,8 +20,79 @@ type BuildInfo struct {
 	Date    string
 }
 
+// String returns the version alone, with no program name.
+//
+// It used to begin with "ddt ", which cobra's version template then prefixed with its
+// own "{{.Name}} version …" — printing `ddt version ddt 2.2.0 (a528ffd…) built …`.
+// Whoever prints this already knows which program it is.
 func (b BuildInfo) String() string {
-	return fmt.Sprintf("ddt %s (%s) built %s %s/%s", b.Version, b.Commit, b.Date, runtime.GOOS, runtime.GOARCH)
+	if b.Version == "" {
+		return "dev"
+	}
+	return b.Version
+}
+
+// Details returns the indented lines shown beneath the version: where the build came
+// from, when, and what built it.
+//
+// Fields a build from source does not have are left out rather than printed as "none"
+// or an empty value, so `ddt --version` never shows a label with nothing after it.
+func (b BuildInfo) Details() string {
+	var lines []string
+
+	if c := b.Commit; c != "" && c != "none" && c != "unknown" {
+		// Short form, as git shows it. The tag identifies a release exactly; this is
+		// for telling two builds apart at a glance.
+		if len(c) > 7 {
+			c = c[:7]
+		}
+		lines = append(lines, "  commit  "+c)
+	}
+	if d := b.built(); d != "" {
+		lines = append(lines, "  built   "+d)
+	}
+	lines = append(lines, fmt.Sprintf("  go      %s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH))
+
+	return strings.Join(lines, "\n") + "\n"
+}
+
+// built renders the build stamp readably, with its age. The stamp is fixed when the
+// binary is compiled; the age is worked out when you run it.
+func (b BuildInfo) built() string {
+	if b.Date == "" || b.Date == "unknown" {
+		return ""
+	}
+	t, err := time.Parse(time.RFC3339, b.Date)
+	if err != nil {
+		// Better to show the raw stamp than to hide it because it is in a shape this
+		// does not recognise.
+		return b.Date
+	}
+	return fmt.Sprintf("%s (%s)", t.UTC().Format("2006-01-02 15:04 UTC"), age(time.Since(t)))
+}
+
+func age(d time.Duration) string {
+	switch {
+	case d < 0:
+		// A stamp in the future means clock skew somewhere; say so rather than
+		// printing a negative age.
+		return "clock skew"
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return plural(int(d.Minutes()), "minute") + " ago"
+	case d < 24*time.Hour:
+		return plural(int(d.Hours()), "hour") + " ago"
+	default:
+		return plural(int(d.Hours()/24), "day") + " ago"
+	}
+}
+
+func plural(n int, unit string) string {
+	if n == 1 {
+		return "1 " + unit
+	}
+	return fmt.Sprintf("%d %ss", n, unit)
 }
 
 // App is the top-level application container holding all services.

--- a/internal/app/build_test.go
+++ b/internal/app/build_test.go
@@ -1,0 +1,103 @@
+package app
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// The bug this pair of methods exists to fix: String() began with the program name, and
+// cobra's version template prefixes its own, so `ddt --version` said
+// "ddt version ddt 2.2.0 (…) built …".
+func TestStringDoesNotRepeatTheProgramName(t *testing.T) {
+	b := BuildInfo{Version: "2.2.0", Commit: "a528ffd1cb217ea9fe076e91862ffec16bd550f8"}
+	if got := b.String(); got != "2.2.0" {
+		t.Errorf("String() = %q, want just the version", got)
+	}
+	if strings.Contains(b.String(), "ddt") {
+		t.Errorf("String() names the program: %q", b.String())
+	}
+}
+
+func TestStringFallsBackToDev(t *testing.T) {
+	if got := (BuildInfo{}).String(); got != "dev" {
+		t.Errorf("String() = %q, want %q for an unstamped build", got, "dev")
+	}
+}
+
+func TestDetailsShortensTheCommit(t *testing.T) {
+	b := BuildInfo{Version: "2.2.0", Commit: "a528ffd1cb217ea9fe076e91862ffec16bd550f8"}
+	got := b.Details()
+	if !strings.Contains(got, "commit  a528ffd\n") {
+		t.Errorf("commit not shortened to 7 characters:\n%s", got)
+	}
+	if strings.Contains(got, "a528ffd1") {
+		t.Errorf("full sha still present:\n%s", got)
+	}
+}
+
+// A build from source has no commit or date, and goreleaser writes "none" when it has
+// nothing. Printing "commit  none" is worse than printing nothing.
+func TestDetailsOmitsWhatItDoesNotKnow(t *testing.T) {
+	for _, commit := range []string{"", "none", "unknown"} {
+		got := BuildInfo{Version: "dev", Commit: commit}.Details()
+		if strings.Contains(got, "commit") {
+			t.Errorf("commit=%q produced a commit line:\n%s", commit, got)
+		}
+		if strings.Contains(got, "built") {
+			t.Errorf("commit=%q produced a built line with no date:\n%s", commit, got)
+		}
+		// The toolchain and platform are always known, so that line is always there.
+		if !strings.Contains(got, "go      ") {
+			t.Errorf("commit=%q lost the go line:\n%s", commit, got)
+		}
+		for _, line := range strings.Split(strings.TrimRight(got, "\n"), "\n") {
+			if strings.TrimSpace(strings.SplitN(strings.TrimSpace(line), " ", 2)[1]) == "" {
+				t.Errorf("a label was printed with nothing after it: %q", line)
+			}
+		}
+	}
+}
+
+func TestDetailsShowsTheDateWithItsAge(t *testing.T) {
+	stamp := time.Now().UTC().Add(-3 * time.Hour).Format(time.RFC3339)
+	got := BuildInfo{Version: "2.2.0", Date: stamp}.Details()
+	if !strings.Contains(got, "3 hours ago") {
+		t.Errorf("age missing or wrong:\n%s", got)
+	}
+	if !strings.Contains(got, "UTC") {
+		t.Errorf("date not rendered readably:\n%s", got)
+	}
+	if strings.Contains(got, stamp) {
+		t.Errorf("raw RFC3339 stamp shown verbatim:\n%s", got)
+	}
+}
+
+// An unparseable stamp should still be shown. Hiding it because it is in an unexpected
+// shape loses the only record of when the binary was built.
+func TestDetailsKeepsAnUnparseableDate(t *testing.T) {
+	got := BuildInfo{Version: "2.2.0", Date: "last Tuesday"}.Details()
+	if !strings.Contains(got, "last Tuesday") {
+		t.Errorf("unparseable stamp was dropped:\n%s", got)
+	}
+}
+
+func TestAge(t *testing.T) {
+	for _, c := range []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "just now"},
+		{time.Minute, "1 minute ago"},
+		{5 * time.Minute, "5 minutes ago"},
+		{time.Hour, "1 hour ago"},
+		{3 * time.Hour, "3 hours ago"},
+		{25 * time.Hour, "1 day ago"},
+		{72 * time.Hour, "3 days ago"},
+		{-time.Hour, "clock skew"},
+	} {
+		if got := age(c.d); got != c.want {
+			t.Errorf("age(%s) = %q, want %q", c.d, got, c.want)
+		}
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -19,6 +19,11 @@ and script execution with dependency resolution.`,
 		Version:       application.Build.String(),
 	}
 
+	// cobra's default template is "{{.Name}} version {{.Version}}", and Version used to
+	// carry the program name too. Dropping "version" as well: `ddt 2.2.0` reads better
+	// than `ddt version 2.2.0`, and matches how the details beneath it are laid out.
+	root.SetVersionTemplate("{{.Name}} {{.Version}}\n" + application.Build.Details())
+
 	// Global flags.
 	root.PersistentFlags().Bool("debug", false, "enable debug output")
 

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -13,9 +13,9 @@ func newVersionCmd(a *app.App) *cobra.Command {
 		Short: "Show version information",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// The same output as `ddt --version`, so the two cannot drift apart.
-			fmt.Fprintf(cmd.OutOrStdout(), "%s %s\n%s",
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "%s %s\n%s",
 				cmd.Root().Name(), a.Build.String(), a.Build.Details())
-			return nil
+			return err
 		},
 	}
 }

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -12,7 +12,9 @@ func newVersionCmd(a *app.App) *cobra.Command {
 		Use:   "version",
 		Short: "Show version information",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println(a.Build.String())
+			// The same output as `ddt --version`, so the two cannot drift apart.
+			fmt.Fprintf(cmd.OutOrStdout(), "%s %s\n%s",
+				cmd.Root().Name(), a.Build.String(), a.Build.Details())
 			return nil
 		},
 	}

--- a/internal/config/images.go
+++ b/internal/config/images.go
@@ -32,9 +32,15 @@ func ReconcileImage(service, current, expected string, custom bool) (next, note 
 	case custom:
 		// Declared as the user's own: never touched, whatever the binary expects.
 		return current, ""
-	case expected == "":
-		// Nothing stamped — a build from source. Leave the file as it is rather than
-		// blanking a working configuration.
+	case !isPinned(expected):
+		// No instruction to act on. This covers both an unstamped build (expected is
+		// empty) and a build from source, where expected is the `:latest` default from
+		// defaults.go — which is NOT the absence of an opinion but the opposite one.
+		//
+		// 2.2.0 shipped without this and consequently unpinned itself: running a
+		// locally built ddt once replaced all three digests a release had written and
+		// announced each one. A floating tag means this binary does not know which
+		// build it wants, so it must not overrule one that did.
 		return current, ""
 	case current == expected:
 		return current, ""
@@ -45,6 +51,14 @@ func ReconcileImage(service, current, expected string, custom bool) (next, note 
 			"%s: replaced docker_image (was %s) with %s — add \"custom_image\": true beside it to keep your own",
 			service, shortRef(current), shortRef(expected))
 	}
+}
+
+// isPinned reports whether a reference names one exact build.
+//
+// Only a digest does. A tag — `:latest`, `:2.2.0`, anything — is a pointer its publisher
+// can move, which is the whole reason this file exists.
+func isPinned(ref string) bool {
+	return strings.Contains(ref, "@sha256:")
 }
 
 // shortRef abbreviates an image reference for display. A digest-pinned ghcr.io

--- a/internal/config/images_test.go
+++ b/internal/config/images_test.go
@@ -59,6 +59,32 @@ func TestReconcileImage(t *testing.T) {
 		}
 	})
 
+	// Shipped broken in 2.2.0: the defaults in defaults.go are `:latest`, so a build
+	// from source has expected = "…:latest" rather than "". That is not "no opinion",
+	// it is the opposite opinion, and it UNPINNED a config a release had pinned —
+	// running a locally built ddt once replaced all three digests and announced it.
+	//
+	// Only a digest is an instruction. A floating tag means this binary does not know
+	// which build it wants, so it must not overrule one that did.
+	t.Run("a source build does not unpin a pinned config", func(t *testing.T) {
+		next, note := ReconcileImage("proxy", expected, "ghcr.io/antimatter-studios/docker-proxy:latest", false)
+		if next != expected {
+			t.Errorf("next = %q, want the pinned digest %q left alone", next, expected)
+		}
+		if note != "" {
+			t.Errorf("note = %q, want silence — nothing should have changed", note)
+		}
+	})
+
+	// The same rule must not stop a release from correcting a `:latest` config, which is
+	// the case the mechanism exists for.
+	t.Run("a pinned build still corrects a floating config", func(t *testing.T) {
+		next, note := ReconcileImage("proxy", "ghcr.io/antimatter-studios/docker-proxy:latest", expected, false)
+		if next != expected || note == "" {
+			t.Errorf("next = %q note = %q, want the digest applied and reported", next, note)
+		}
+	})
+
 	// A real digest reference is ~110 characters, so a note naming two of them is a
 	// ~230-character line that wraps several times and hides its own point.
 	t.Run("a note stays readable with real-length references", func(t *testing.T) {


### PR DESCRIPTION
Two fixes, found by looking at what `ddt --version` actually printed after 2.2.0.

### `ddt version ddt 2.2.0`

```
ddt version ddt 2.2.0 (a528ffd1cb217ea9fe076e91862ffec16bd550f8) built 2026-07-29T07:20:17Z darwin/arm64
```

`BuildInfo.String()` began with the program name and cobra's version template prefixes its own `{{.Name}} version`, so the name appeared twice. Plus a 40-character sha and a raw RFC3339 stamp on one long line.

Now:

```
ddt 2.2.0
  commit  a528ffd
  built   2026-07-29 07:20 UTC (3 hours ago)
  go      go1.25.0 darwin/arm64
```

The age is computed when you run it; the stamp is fixed at build time. A source build omits what it does not know rather than printing `commit  none`:

```
ddt dev
  go      go1.26.5 darwin/arm64
```

`ddt version` and `ddt --version` now go through the same two methods, so they cannot drift.

### A source build unpinned the digests 2.2.0 had just pinned

Worth calling out, because 2.2.0 is released with this:

```
dns: replaced docker_image (was docker-dns@sha256:49cb2bda2487) with docker-dns:latest — …
proxy: replaced docker_image (was docker-proxy@sha256:ead2db1e9716) with docker-proxy:latest — …
config_gen: replaced docker_image (was docker-config-gen@sha256:f17823bb1871) with docker-config-gen:latest — …
```

That is a locally built ddt undoing a release's pinning on first run. `ReconcileImage` treated an empty `expected` as "this binary has no opinion" — but the defaults in `defaults.go` are `:latest`, so a source build never has an empty one. It has the **opposite** opinion, and it won; the branch was unreachable.

Only a digest counts as an instruction now. A tag is a pointer its publisher can move — the reason the pinning exists at all — so a binary holding one must not overrule a binary that had a digest. A release still corrects a `:latest` config, which is the case the feature is for.

Both directions are tested, and the new test fails against 2.2.0's code.

### Verified

- built with ldflags and ran it: output is as shown above, for both `--version` and `version`
- built from source against a digest-pinned config: nothing rewritten, nothing printed
- 8 new tests in `internal/app`, 2 new in `internal/config`

Wants a 2.2.1 once merged, since 2.2.0 will unpin itself for anyone who also builds from source.