### PR TITLE
Add an MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Antimatter Studios
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This repository has no LICENSE file, so ddt is published with no terms at all — anyone installing it has no stated permission to use, modify or redistribute it.

It also makes a claim elsewhere false. `antimatter-studios/homebrew-tap`'s `Formula/ddt.rb` declares:

```ruby
license "MIT"
```

That was added in antimatter-studios/homebrew-tap#33 on the strength of a misread command output, and it has been asserting a license this repository never stated. This merging is what makes it true — no change is needed in the tap.

MIT, and copyright attributed to "Antimatter Studios", matching `antimatter-studios/chore`.

Nothing else changes. ddt's release pipeline already stopped writing into the tap in #4, so there is no packaging work left here.